### PR TITLE
:bug: Using the wrong method to generate the upgrade spec

### DIFF
--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/docker/docker/api/types"
 	events "github.com/kairos-io/kairos-sdk/bus"
@@ -147,11 +146,10 @@ func Upgrade(
 	upgradeConfig.Luet = l
 
 	// Generate the upgrade spec
-	upgradeSpec, err := elementalConfig.ReadUpgradeSpec(upgradeConfig)
+	upgradeSpec, err := elementalConfig.NewUpgradeSpec(upgradeConfig.Config)
 	if err != nil {
 		return err
 	}
-
 	// Add the image source
 	imgSource, err := v1.NewSrcFromURI(fmt.Sprintf("docker:%s", img))
 	if err != nil {


### PR DESCRIPTION
The older method was used in conjuntion with viper flags and automatically picked the image source flag, so it was not an issue that the method calls sanitize as the image source came from the cli directly.

But now we manually set the image source into the spec due to not using viper, so we have to first parse the source, set it in the spec and then call sanitized to see if we have the required spec filled.