### PR TITLE
Allow overriding the schem version number

### DIFF
--- a/main.go
+++ b/main.go
@@ -464,9 +464,21 @@ The validate command expects a configuration file as its only argument. Local fi
 	},
 	{
 		Name: "print-schema",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "version",
+				Usage: "Print the current schema but with another version number, instead of using the agent version number.",
+			},
+		},
 		Action: func(c *cli.Context) error {
+			var version string
+			if c.String("version") != "" {
+				version = c.String("version")
+			} else {
+				version = common.VERSION
+			}
 
-			json, err := agent.JSONSchema(common.VERSION)
+			json, err := agent.JSONSchema(version)
 
 			if err != nil {
 				return err


### PR DESCRIPTION
We currently default to the agent number but there could be reason why we want this being override. For example we dont really sync with the kairos OS release schedule so there is no way we can sync up with that.

This allows to override the version number so systems can generate a schema that is synced to their version number for ease of use.