### PR TITLE
:bug: Read upgrade/install values from config

### DIFF
--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/sanity-io/litter"
 	"net/url"
 	"os"
 	"strings"
@@ -101,6 +102,7 @@ func ManualInstall(c string, options map[string]string, strictValidations, debug
 		return err
 	}
 	installConfig.Debug = debug
+	installConfig.Logger.Debugf("Full config: %s\n", litter.Sdump(installConfig))
 
 	return RunInstall(installConfig, options)
 }
@@ -135,6 +137,7 @@ func Install(debug bool, dir ...string) error {
 		return err
 	}
 	installConfig.Debug = debug
+	installConfig.Logger.Debugf("Full config: %s\n", litter.Sdump(installConfig))
 
 	// Reads config, and if present and offline is defined,
 	// runs the installation
@@ -302,7 +305,7 @@ func RunInstall(installConfig *v1.RunConfig, options map[string]string) error {
 	}
 
 	// Generate the installation spec
-	installSpec := elementalConfig.NewInstallSpec(installConfig.Config)
+	installSpec, _ := elementalConfig.ReadInstallSpec(installConfig)
 
 	installSpec.NoFormat = c.Install.NoFormat
 

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/sanity-io/litter"
 	"github.com/sirupsen/logrus"
 	"os"
 	"sync"
@@ -89,6 +90,7 @@ func Reset(debug bool, dir ...string) error {
 	if debug {
 		resetConfig.Logger.SetLevel(logrus.DebugLevel)
 	}
+	resetConfig.Logger.Debugf("Full config: %s\n", litter.Sdump(resetConfig))
 	resetSpec, err := elementalConfig.ReadResetSpec(resetConfig)
 	if err != nil {
 		return err

--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kairos-io/kairos/v2/pkg/github"
 	v1 "github.com/kairos-io/kairos/v2/pkg/types/v1"
 	"github.com/mudler/go-pluggable"
+	"github.com/sanity-io/litter"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -127,12 +128,10 @@ func Upgrade(
 
 	// Set image to local if true
 	upgradeConfig.LocalImage = isLocal
+	upgradeConfig.Logger.Debugf("Full config: %s\n", litter.Sdump(upgradeConfig))
 
 	// Generate the upgrade spec
-	upgradeSpec, err := elementalConfig.NewUpgradeSpec(upgradeConfig.Config)
-	if err != nil {
-		return err
-	}
+	upgradeSpec, _ := elementalConfig.ReadUpgradeSpec(upgradeConfig)
 	// Add the image source
 	imgSource, err := v1.NewSrcFromURI(img)
 	if err != nil {


### PR DESCRIPTION
We were ignoring the values in the /etc/elemental/config.yaml file that we loaded into viper by not reading those values and their keys into the final spec.

This meant that for example the defautl entry name was being lost as we generated a new install spec from scratch and ignored those values that we read on the config