### PR TITLE
Drop --local flag for image sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jaypipes/ghw v0.10.0
 	github.com/joho/godotenv v1.5.1
-	github.com/kairos-io/kairos-sdk v0.0.8
+	github.com/kairos-io/kairos-sdk v0.0.9-0.20230620064343-df990bf49a07
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/mudler/go-nodepair v0.0.0-20221223092639-ba399a66fdfb

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kairos-io/kairos-sdk v0.0.8 h1:3yfxdmUuJoN7ePg+ogpH1PJvuMsLmLcxEXuWoiGdIrg=
 github.com/kairos-io/kairos-sdk v0.0.8/go.mod h1:Z+1CLqMZq97bzwX2XSIArr8EoniMth3mMYkOOb8L3QY=
+github.com/kairos-io/kairos-sdk v0.0.9-0.20230620064343-df990bf49a07 h1:WctdkLqZBl8bViFPoqnRtxU5Vf63G9c1lTLem6F3d4s=
+github.com/kairos-io/kairos-sdk v0.0.9-0.20230620064343-df990bf49a07/go.mod h1:Z+1CLqMZq97bzwX2XSIArr8EoniMth3mMYkOOb8L3QY=
 github.com/kbinani/screenshot v0.0.0-20210720154843-7d3a670d8329 h1:qq2nCpSrXrmvDGRxW0ruW9BVEV1CN2a9YDOExdt+U0o=
 github.com/kbinani/screenshot v0.0.0-20210720154843-7d3a670d8329/go.mod h1:2VPVQDR4wO7KXHwP+DAypEy67rXf+okUx2zjgpCxZw4=
 github.com/kendru/darwin/go/depgraph v0.0.0-20221105232959-877d6a81060c h1:eKb4PqwAMhlqwXw0W3atpKaYaPGlXE/Fwh+xpCEYaPk=

--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -48,8 +48,7 @@ func ListReleases(includePrereleases bool) semver.Collection {
 }
 
 func Upgrade(
-	version, source string, force, debug, strictValidations bool, dirs []string, preReleases, isLocal bool,
-) error {
+	version, source string, force, debug, strictValidations bool, dirs []string, preReleases bool) error {
 	bus.Manager.Initialize()
 
 	if version == "" && source == "" {
@@ -126,8 +125,6 @@ func Upgrade(
 		upgradeConfig.Logger.SetLevel(log.DebugLevel)
 	}
 
-	// Set image to local if true
-	upgradeConfig.LocalImage = isLocal
 	upgradeConfig.Logger.Debugf("Full config: %s\n", litter.Sdump(upgradeConfig))
 
 	// Generate the upgrade spec

--- a/main.go
+++ b/main.go
@@ -69,7 +69,6 @@ var cmds = []*cli.Command{
 				Usage: "Source for upgrade. Composed of `type:address`. Accepts `file:`,`dir:` or `oci:` for the type of source.\nFor example `file:/var/share/myimage.tar`, `dir:/tmp/extracted` or `oci:repo/image:tag`",
 			},
 			&cli.BoolFlag{Name: "pre", Usage: "Include pre-releases (rc, beta, alpha)"},
-			&cli.BoolFlag{Name: "local", Usage: "Get the upgrade source image from local daemon"},
 		},
 		Description: `
 Manually upgrade a kairos node.
@@ -135,11 +134,10 @@ See https://kairos.io/docs/upgrade/manual/ for documentation.
 				source = fmt.Sprintf("oci:%s", image)
 			}
 
-			isLocal := c.Bool("local")
 			return agent.Upgrade(
 				v, source, c.Bool("force"), c.Bool("debug"),
 				c.Bool("strict-validation"), configScanDir,
-				c.Bool("pre"), isLocal,
+				c.Bool("pre"),
 			)
 		},
 	},
@@ -559,11 +557,6 @@ The validate command expects a configuration file as its only argument. Local fi
 		Usage:       "Pull remote image to local file",
 		UsageText:   "pull-image [-l] IMAGE TARGET",
 		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:    "local",
-				Usage:   "Use an image from local cache",
-				Aliases: []string{"l"},
-			},
 			&cli.StringFlag{
 				Name:  "platform",
 				Usage: "Platform/arch to pull image from",
@@ -599,7 +592,7 @@ The validate command expects a configuration file as its only argument. Local fi
 
 			cfg.Logger.Infof("Starting download and extraction for image %s to %s\n", image, destination)
 			e := v1.OCIImageExtractor{}
-			if err = e.ExtractImage(image, destination, c.String("platform"), c.Bool("local")); err != nil {
+			if err = e.ExtractImage(image, destination, c.String("platform")); err != nil {
 				return err
 			}
 			cfg.Logger.Infof("Image %s downloaded and extracted to %s correctly\n", image, destination)

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -344,7 +344,7 @@ var _ = Describe("Install action tests", func() {
 
 		It("Fails if luet fails to unpack image", Label("image", "luet", "unpack"), func() {
 			spec.Target = device
-			extractor.SideEffect = func(imageRef, destination, platformRef string, local bool) error {
+			extractor.SideEffect = func(imageRef, destination, platformRef string) error {
 				return fmt.Errorf("error")
 			}
 			spec.Active.Source = v1.NewDockerSrc("my/image:latest")

--- a/pkg/action/reset_test.go
+++ b/pkg/action/reset_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Reset action tests", func() {
 		})
 		It("Fails unpacking docker image ", func() {
 			spec.Active.Source = v1.NewDockerSrc("my/image:latest")
-			extractor.SideEffect = func(imageRef, destination, platformRef string, local bool) error {
+			extractor.SideEffect = func(imageRef, destination, platformRef string) error {
 				return fmt.Errorf("error")
 			}
 			Expect(reset.Run()).NotTo(BeNil())

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -363,7 +363,7 @@ func (e *Elemental) DumpSource(target string, imgSrc *v1.ImageSource) (info inte
 				return nil, err
 			}
 		}
-		err = e.config.ImageExtractor.ExtractImage(imgSrc.Value(), target, e.config.Platform.String(), e.config.LocalImage)
+		err = e.config.ImageExtractor.ExtractImage(imgSrc.Value(), target, e.config.Platform.String())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -52,7 +52,6 @@ type Config struct {
 	Cosign                    bool         `yaml:"cosign,omitempty" mapstructure:"cosign"`
 	Verify                    bool         `yaml:"verify,omitempty" mapstructure:"verify"`
 	CosignPubKey              string       `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
-	LocalImage                bool         `yaml:"local,omitempty" mapstructure:"local"`
 	Repos                     []Repository `yaml:"repositories,omitempty" mapstructure:"repositories"`
 	Arch                      string       `yaml:"arch,omitempty" mapstructure:"arch"`
 	SquashFsCompressionConfig []string     `yaml:"squash-compression,omitempty" mapstructure:"squash-compression"`

--- a/pkg/types/v1/image.go
+++ b/pkg/types/v1/image.go
@@ -21,13 +21,13 @@ import (
 )
 
 type ImageExtractor interface {
-	ExtractImage(imageRef, destination, platformRef string, local bool) error
+	ExtractImage(imageRef, destination, platformRef string) error
 }
 
 type OCIImageExtractor struct{}
 
 var _ ImageExtractor = OCIImageExtractor{}
 
-func (e OCIImageExtractor) ExtractImage(imageRef, destination, platformRef string, local bool) error {
-	return utils.ExtractOCIImage(imageRef, destination, platformRef, local)
+func (e OCIImageExtractor) ExtractImage(imageRef, destination, platformRef string) error {
+	return utils.ExtractOCIImage(imageRef, destination, platformRef)
 }

--- a/tests/mocks/extractor_mock.go
+++ b/tests/mocks/extractor_mock.go
@@ -20,7 +20,7 @@ import v1 "github.com/kairos-io/kairos/v2/pkg/types/v1"
 
 type FakeImageExtractor struct {
 	Logger     v1.Logger
-	SideEffect func(imageRef, destination, platformRef string, local bool) error
+	SideEffect func(imageRef, destination, platformRef string) error
 }
 
 var _ v1.ImageExtractor = FakeImageExtractor{}
@@ -34,11 +34,11 @@ func NewFakeImageExtractor(logger v1.Logger) *FakeImageExtractor {
 	}
 }
 
-func (f FakeImageExtractor) ExtractImage(imageRef, destination, platformRef string, local bool) error {
+func (f FakeImageExtractor) ExtractImage(imageRef, destination, platformRef string) error {
 	f.Logger.Debugf("extracting %s to %s in platform %s", imageRef, destination, platformRef)
 	if f.SideEffect != nil {
 		f.Logger.Debugf("running side effect")
-		return f.SideEffect(imageRef, destination, platformRef, local)
+		return f.SideEffect(imageRef, destination, platformRef)
 	}
 
 	return nil


### PR DESCRIPTION
The extractor will now auto try to get it from the local daemon first and then drop to remote one like the docker client

Requires: https://github.com/kairos-io/kairos-sdk/pull/32