### PR TITLE
Load elemental config/spec from cloud config

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -31,7 +31,7 @@ type Config struct {
 
 func LoadConfig(path ...string) (*Config, error) {
 	if len(path) == 0 {
-		path = append(path, "/etc/kairos/agent.yaml", "/etc/elemental/config.yaml")
+		path = append(path, "/etc/kairos/agent.yaml")
 	}
 
 	cfg := &Config{}

--- a/internal/agent/hooks/runstage.go
+++ b/internal/agent/hooks/runstage.go
@@ -11,11 +11,7 @@ import (
 type RunStage struct{}
 
 func (r RunStage) Run(c config.Config) error {
-	cc, err := c.String()
-	if err != nil {
-		return err
-	}
-	cfg, err := elementalConfig.ReadConfigRunFromCloudConfig(cc)
+	cfg, err := elementalConfig.ReadConfigRunFromAgentConfig(&c)
 	if err != nil {
 		cfg.Logger.Errorf("Error reading config: %s\n", err)
 	}

--- a/internal/agent/hooks/runstage.go
+++ b/internal/agent/hooks/runstage.go
@@ -10,8 +10,12 @@ import (
 
 type RunStage struct{}
 
-func (r RunStage) Run(_ config.Config) error {
-	cfg, err := elementalConfig.ReadConfigRun("/etc/elemental")
+func (r RunStage) Run(c config.Config) error {
+	cc, err := c.String()
+	if err != nil {
+		return err
+	}
+	cfg, err := elementalConfig.ReadConfigRunFromCloudConfig(cc)
 	if err != nil {
 		cfg.Logger.Errorf("Error reading config: %s\n", err)
 	}

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -266,8 +266,17 @@ func RunInstall(options map[string]string) error {
 	env := append(c.Install.Env, c.Env...)
 	utils.SetEnv(env)
 
+	_, reboot := options["reboot"]
+	_, poweroff := options["poweroff"]
+	if poweroff {
+		c.Install.Poweroff = true
+	}
+	if reboot {
+		c.Install.Reboot = true
+	}
+
 	// Load the installation Config from the system
-	installConfig, err := elementalConfig.ReadConfigRunFromCloudConfig(cloudInit)
+	installConfig, installSpec, err := elementalConfig.ReadInstallConfigFromAgentConfig(c)
 	if err != nil {
 		return err
 	}
@@ -285,17 +294,6 @@ func RunInstall(options map[string]string) error {
 		return err
 	}
 
-	_, reboot := options["reboot"]
-	_, poweroff := options["poweroff"]
-	if poweroff {
-		c.Install.Poweroff = true
-	}
-	if reboot {
-		c.Install.Reboot = true
-	}
-
-	// Generate the installation spec
-	installSpec, _ := elementalConfig.ReadInstallSpecFromCloudConfig(installConfig)
 	installSpec.NoFormat = c.Install.NoFormat
 
 	// Set our cloud-init to the file we just created

--- a/internal/agent/install_test.go
+++ b/internal/agent/install_test.go
@@ -1,18 +1,15 @@
 package agent
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"github.com/jaypipes/ghw/pkg/block"
 	"github.com/kairos-io/kairos-agent/v2/pkg/constants"
-	conf "github.com/kairos-io/kairos-agent/v2/pkg/elementalConfig"
 	"github.com/kairos-io/kairos-agent/v2/pkg/utils"
 	"os"
 	"path/filepath"
 
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
-	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	v1mock "github.com/kairos-io/kairos-agent/v2/tests/mocks"
 	"github.com/twpayne/go-vfs"
 	"github.com/twpayne/go-vfs/vfst"
@@ -66,27 +63,17 @@ var _ = Describe("prepareConfiguration", func() {
 })
 
 var _ = Describe("RunInstall", func() {
-	var installConfig *v1.RunConfig
 	var options map[string]string
 	var err error
 	var fs vfs.FS
-	var cloudInit *v1mock.FakeCloudInitRunner
 	var cleanup func()
-	var memLog *bytes.Buffer
 	var ghwTest v1mock.GhwMock
 	var cmdline func() ([]byte, error)
 
 	BeforeEach(func() {
 		// Default mock objects
 		runner := v1mock.NewFakeRunner()
-		syscall := &v1mock.FakeSyscall{}
-		mounter := v1mock.NewErrorMounter()
-		memLog = &bytes.Buffer{}
-		logger := v1.NewBufferLogger(memLog)
-		logger = v1.NewLogger()
-		extractor := v1mock.NewFakeImageExtractor(logger)
 		//logger.SetLevel(v1.DebugLevel())
-		cloudInit = &v1mock.FakeCloudInitRunner{}
 		// Set default cmdline function so we dont panic :o
 		cmdline = func() ([]byte, error) {
 			return []byte{}, nil
@@ -104,17 +91,6 @@ var _ = Describe("RunInstall", func() {
 		Expect(err).To(BeNil())
 		_, err = fs.Create(grubCfg)
 		Expect(err).To(BeNil())
-
-		// Create new runconfig with all mocked objects
-		installConfig = conf.NewRunConfig(
-			conf.WithFs(fs),
-			conf.WithRunner(runner),
-			conf.WithLogger(logger),
-			conf.WithMounter(mounter),
-			conf.WithSyscall(syscall),
-			conf.WithCloudInitRunner(cloudInit),
-			conf.WithImageExtractor(extractor),
-		)
 
 		// Side effect of runners, hijack calls to commands and return our stuff
 		partNum := 0
@@ -225,7 +201,7 @@ install:
 
 	It("runs the install", func() {
 		Skip("Not ready yet")
-		err = RunInstall(installConfig, options)
+		err = RunInstall(options)
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/internal/agent/interactive_install.go
+++ b/internal/agent/interactive_install.go
@@ -280,8 +280,8 @@ func InteractiveInstall(debug, spawnShell bool) error {
 	// Set debug from here already, so it's loaded by the ReadConfigRun
 	viper.Set("debug", debug)
 
-	// Load the installation Config from the system
-	installConfig, err := elementalConfig.ReadConfigRun("/etc/elemental")
+	// Load the installation Config from the cloud-config data
+	installConfig, err := elementalConfig.ReadConfigRunFromCloudConfig(finalCloudConfig)
 	if err != nil {
 		return err
 	}

--- a/internal/agent/interactive_install.go
+++ b/internal/agent/interactive_install.go
@@ -8,8 +8,6 @@ import (
 	"github.com/kairos-io/kairos-agent/v2/internal/bus"
 	"github.com/kairos-io/kairos-agent/v2/internal/cmd"
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
-	"github.com/kairos-io/kairos-agent/v2/pkg/elementalConfig"
-
 	events "github.com/kairos-io/kairos-sdk/bus"
 	"github.com/kairos-io/kairos-sdk/unstructured"
 
@@ -279,14 +277,8 @@ func InteractiveInstall(debug, spawnShell bool) error {
 
 	// Set debug from here already, so it's loaded by the ReadConfigRun
 	viper.Set("debug", debug)
-
-	// Load the installation Config from the cloud-config data
-	installConfig, err := elementalConfig.ReadConfigRunFromCloudConfig(finalCloudConfig)
-	if err != nil {
-		return err
-	}
-
-	err = RunInstall(installConfig, map[string]string{
+	
+	err = RunInstall(map[string]string{
 		"device": device,
 		"cc":     finalCloudConfig,
 	})

--- a/internal/agent/interactive_install.go
+++ b/internal/agent/interactive_install.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mudler/go-pluggable"
 	"github.com/mudler/yip/pkg/schema"
 	"github.com/pterm/pterm"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -275,9 +274,6 @@ func InteractiveInstall(debug, spawnShell bool) error {
 	pterm.Info.Println("Starting installation")
 	pterm.Info.Println(finalCloudConfig)
 
-	// Set debug from here already, so it's loaded by the ReadConfigRun
-	viper.Set("debug", debug)
-	
 	err = RunInstall(map[string]string{
 		"device": device,
 		"cc":     finalCloudConfig,

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -42,7 +42,6 @@ func Reset(debug bool, dir ...string) error {
 
 	// This loads yet another config ¬_¬
 	// TODO: merge this somehow with the rest so there is no 5 places to configure stuff?
-	// Also this reads the elemental config.yaml
 	agentConfig, err := LoadConfig()
 	if err != nil {
 		return err

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -49,32 +49,29 @@ func Reset(debug bool, dir ...string) error {
 
 	cmd.PrintText(agentConfig.Branding.Reset, "Reset")
 
-	/*
-		// We don't close the lock, as none of the following actions are expected to return
-		lock := sync.Mutex{}
-		go func() {
-			// Wait for user input and go back to shell
-			utils.Prompt("") //nolint:errcheck
-			// give tty1 back
-			svc, err := machine.Getty(1)
-			if err == nil {
-				svc.Start() //nolint:errcheck
-			}
-
-			lock.Lock()
-			fmt.Println("Reset aborted")
-			panic(utils.Shell().Run())
-		}()
-
-		if !agentConfig.Fast {
-			time.Sleep(60 * time.Second)
+	// We don't close the lock, as none of the following actions are expected to return
+	lock := sync.Mutex{}
+	go func() {
+		// Wait for user input and go back to shell
+		utils.Prompt("") //nolint:errcheck
+		// give tty1 back
+		svc, err := machine.Getty(1)
+		if err == nil {
+			svc.Start() //nolint:errcheck
 		}
+
 		lock.Lock()
+		fmt.Println("Reset aborted")
+		panic(utils.Shell().Run())
+	}()
 
-		ensureDataSourceReady()
+	if !agentConfig.Fast {
+		time.Sleep(60 * time.Second)
+	}
+	lock.Lock()
 
+	ensureDataSourceReady()
 
-	*/
 	bus.Manager.Publish(sdk.EventBeforeReset, sdk.EventPayload{}) //nolint:errcheck
 
 	c, err := config.Scan(collector.Directories(dir...))

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"sync"
 	"time"
@@ -23,7 +22,7 @@ import (
 	"github.com/pterm/pterm"
 )
 
-func Reset(debug bool, dir ...string) error {
+func Reset(dir ...string) error {
 	// TODO: Enable args? No args for now so no possibility of reset persistent or overriding the source for the reset
 	// Nor the auto-reboot via cmd?
 	// This comment pertains calling reset via cmdline when wanting to override configs
@@ -81,23 +80,12 @@ func Reset(debug bool, dir ...string) error {
 
 	utils.SetEnv(c.Env)
 
-	cc, err := c.String()
-	if err != nil {
-		return err
-	}
 	// Load the installation Config from the cloud-config data
-	resetConfig, err := elementalConfig.ReadConfigRunFromCloudConfig(cc)
+	resetConfig, resetSpec, err := elementalConfig.ReadResetConfigFromAgentConfig(c)
 	if err != nil {
 		return err
 	}
 
-	if debug {
-		resetConfig.Logger.SetLevel(logrus.DebugLevel)
-	}
-	resetSpec, err := elementalConfig.ReadResetSpecFromCloudConfig(resetConfig)
-	if err != nil {
-		return err
-	}
 	// Not even sure what opts can come from here to be honest. Where is the struct that supports this options?
 	// Where is the docs to support this? This is generic af and not easily identifiable
 	if len(options) == 0 {

--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -6,17 +6,16 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	events "github.com/kairos-io/kairos-sdk/bus"
-	"github.com/kairos-io/kairos-sdk/collector"
-	"github.com/kairos-io/kairos-sdk/utils"
 	"github.com/kairos-io/kairos-agent/v2/internal/bus"
 	"github.com/kairos-io/kairos-agent/v2/pkg/action"
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
 	"github.com/kairos-io/kairos-agent/v2/pkg/elementalConfig"
 	"github.com/kairos-io/kairos-agent/v2/pkg/github"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
+	events "github.com/kairos-io/kairos-sdk/bus"
+	"github.com/kairos-io/kairos-sdk/collector"
+	"github.com/kairos-io/kairos-sdk/utils"
 	"github.com/mudler/go-pluggable"
-	"github.com/sanity-io/litter"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -102,7 +101,11 @@ func Upgrade(
 	utils.SetEnv(c.Env)
 
 	// Load the upgrade Config from the system
-	upgradeConfig, err := elementalConfig.ReadConfigRun("/etc/elemental")
+	cc, err := c.String()
+	if err != nil {
+		return err
+	}
+	upgradeConfig, err := elementalConfig.ReadConfigRunFromCloudConfig(cc)
 	if err != nil {
 		return err
 	}
@@ -110,10 +113,8 @@ func Upgrade(
 		upgradeConfig.Logger.SetLevel(log.DebugLevel)
 	}
 
-	upgradeConfig.Logger.Debugf("Full config: %s\n", litter.Sdump(upgradeConfig))
-
 	// Generate the upgrade spec
-	upgradeSpec, _ := elementalConfig.ReadUpgradeSpec(upgradeConfig)
+	upgradeSpec, _ := elementalConfig.ReadUpgradeSpecFromCloudConfig(upgradeConfig)
 	// Add the image source
 	imgSource, err := v1.NewSrcFromURI(img)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ See https://kairos.io/docs/upgrade/manual/ for documentation.
 			}
 
 			return agent.Upgrade(
-				v, source, c.Bool("force"), c.Bool("debug"),
+				v, source, c.Bool("force"),
 				c.Bool("strict-validation"), configScanDir,
 				c.Bool("pre"),
 			)
@@ -457,7 +457,8 @@ This command is meant to be used from the boot GRUB menu, but can likely be used
 	{
 		Name: "reset",
 		Action: func(c *cli.Context) error {
-			return agent.Reset(c.Bool("debug"), configScanDir...)
+
+			return agent.Reset(configScanDir...)
 		},
 		Usage: "Starts kairos reset mode",
 		Description: `
@@ -539,11 +540,7 @@ The validate command expects a configuration file as its only argument. Local fi
 			if err != nil {
 				return err
 			}
-			cc, err := config.String()
-			if err != nil {
-				return err
-			}
-			cfg, err := elementalConfig.ReadConfigRunFromCloudConfig(cc)
+			cfg, err := elementalConfig.ReadConfigRunFromAgentConfig(config)
 			cfg.Strict = c.Bool("strict")
 
 			if len(c.StringSlice("cloud-init-paths")) > 0 {
@@ -594,11 +591,7 @@ The validate command expects a configuration file as its only argument. Local fi
 			if err != nil {
 				return err
 			}
-			cc, err := config.String()
-			if err != nil {
-				return err
-			}
-			cfg, err := elementalConfig.ReadConfigRunFromCloudConfig(cc)
+			cfg, err := elementalConfig.ReadConfigRunFromAgentConfig(config)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/kairos-io/kairos-agent/v2/pkg/utils"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,7 +18,6 @@ import (
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
 	"github.com/kairos-io/kairos-agent/v2/pkg/elementalConfig"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
-	"github.com/kairos-io/kairos-agent/v2/pkg/utils"
 	"github.com/kairos-io/kairos-sdk/bundles"
 	"github.com/kairos-io/kairos-sdk/collector"
 	"github.com/kairos-io/kairos-sdk/machine"
@@ -535,7 +535,15 @@ The validate command expects a configuration file as its only argument. Local fi
 		},
 		Action: func(c *cli.Context) error {
 			stage := c.Args().First()
-			cfg, err := elementalConfig.ReadConfigRun("/etc/elemental")
+			config, err := config.Scan(collector.Directories(configScanDir...), collector.NoLogs)
+			if err != nil {
+				return err
+			}
+			cc, err := config.String()
+			if err != nil {
+				return err
+			}
+			cfg, err := elementalConfig.ReadConfigRunFromCloudConfig(cc)
 			cfg.Strict = c.Bool("strict")
 
 			if len(c.StringSlice("cloud-init-paths")) > 0 {
@@ -582,7 +590,15 @@ The validate command expects a configuration file as its only argument. Local fi
 			if err != nil {
 				return fmt.Errorf("invalid path %s", destination)
 			}
-			cfg, err := elementalConfig.ReadConfigRun("/etc/elemental")
+			config, err := config.Scan(collector.Directories(configScanDir...), collector.NoLogs)
+			if err != nil {
+				return err
+			}
+			cc, err := config.String()
+			if err != nil {
+				return err
+			}
+			cfg, err := elementalConfig.ReadConfigRunFromCloudConfig(cc)
 			if err != nil {
 				return err
 			}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,7 +24,7 @@ import (
 const (
 	GrubConf                = "/etc/cos/grub.cfg"
 	GrubOEMEnv              = "grub_oem_env"
-	GrubDefEntry            = "cOS"
+	GrubDefEntry            = "Kairos"
 	DefaultTty              = "tty1"
 	BiosPartName            = "bios"
 	EfiLabel                = "COS_GRUB"

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -198,6 +198,10 @@ func (i *InstallSpec) Sanitize() error {
 	return i.Partitions.SetFirmwarePartitions(i.Firmware, i.PartTable)
 }
 
+type Spec interface {
+	Sanitize() error
+}
+
 // ResetSpec struct represents all the reset action details
 type ResetSpec struct {
 	FormatPersistent bool `yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -122,12 +122,13 @@ func (c *Config) Sanitize() error {
 }
 
 type RunConfig struct {
-	Debug          bool     `yaml:"strict,omitempty" mapstructure:"debug"`
-	Strict         bool     `yaml:"strict,omitempty" mapstructure:"strict"`
-	Reboot         bool     `yaml:"reboot,omitempty" mapstructure:"reboot"`
-	PowerOff       bool     `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
-	CloudInitPaths []string `yaml:"cloud-init-paths,omitempty" mapstructure:"cloud-init-paths"`
-	EjectCD        bool     `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
+	Debug           bool     `yaml:"debug,omitempty" mapstructure:"debug"`
+	Strict          bool     `yaml:"strict,omitempty" mapstructure:"strict"`
+	Reboot          bool     `yaml:"reboot,omitempty" mapstructure:"reboot"`
+	PowerOff        bool     `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
+	CloudInitPaths  []string `yaml:"cloud-init-paths,omitempty" mapstructure:"cloud-init-paths"`
+	EjectCD         bool     `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
+	FullCloudConfig string   // Stores the full cloud config used to generate the spec afterwards
 
 	// 'inline' and 'squash' labels ensure config fields
 	// are embedded from a yaml and map PoV


### PR DESCRIPTION
First round.

Picks the config from the cloud config IF its there, otherwise defaults to proper values that we used to ship with the elemental config.

This allows to set any of the old elemental config options via cloud config directly as such:

```
#cloud-config
debug: true
install:
  reboot: true
  grub-entry-name: "MyCustomOS"
  system:
    size: 5000
  recovery-system:
    size: 1400000

cloud-init-paths:
- /run/initramfs/cos-state
```