### PR TITLE
Create .codecov.yaml

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,16 @@
+github_checks:
+  annotations: false
+coverage:
+  status:
+    project:
+      default: false
+      internal:
+        paths:
+         - "internal/"
+        target: 75%
+        informational: true
+      pkg:
+        paths:
+          - "pkg/"
+        target: 75%
+    patch: false


### PR DESCRIPTION
Seems like the old config was still stored on codecov, but once we changed the module name it reset and now we got codecov commenting on PRs and failing the PRs due to not reaching the required code coverage ¬_¬