### PR TITLE
Fix oem mountpoint not available on upgrade

### DIFF
--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -19,17 +19,13 @@ package action
 import (
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	"github.com/kairos-io/kairos-agent/v2/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 // Hook is RunStage wrapper that only adds logic to ignore errors
 // in case v1.RunConfig.Strict is set to false
 func Hook(config *v1.Config, hook string, strict bool, cloudInitPaths ...string) error {
 	config.Logger.Infof("Running %s hook", hook)
-	oldLevel := config.Logger.GetLevel()
-	config.Logger.SetLevel(logrus.ErrorLevel)
 	err := utils.RunStage(config, hook, strict, cloudInitPaths...)
-	config.Logger.SetLevel(oldLevel)
 	if !strict {
 		err = nil
 	}

--- a/pkg/elementalConfig/config.go
+++ b/pkg/elementalConfig/config.go
@@ -369,6 +369,11 @@ func NewUpgradeSpec(cfg v1.Config) (*v1.UpgradeSpec, error) {
 		}
 	}
 
+	// If we have oem in the system, but it has no mountpoint
+	if ep.OEM != nil && ep.OEM.MountPoint == "" {
+		// Add the default mountpoint for it in case the chroot stages want to bind mount it
+		ep.OEM.MountPoint = constants.OEMPath
+	}
 	// This is needed if we want to use the persistent as tmpdir for the upgrade images
 	// as tmpfs is 25% of the total RAM, we cannot rely on the tmp dir having enough space for our image
 	// This enables upgrades on low ram devices


### PR DESCRIPTION
This causes the chroot stages to not be complete as they could not bind mount the current system /oem into the chroot due not being able to infer the oem partition mountpoint, so any cloud-init files in there would be ignored.

Also removes the log downgrade for yip that was useful under yip 0.11.x. Now the logging is nicer and if you want debug logging you get it.