### PR TITLE
Merge data from events into reset

### DIFF
--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -23,24 +23,11 @@ import (
 )
 
 func Reset(dir ...string) error {
-	// TODO: Enable args? No args for now so no possibility of reset persistent or overriding the source for the reset
-	// Nor the auto-reboot via cmd?
-	// This comment pertains calling reset via cmdline when wanting to override configs
 	bus.Manager.Initialize()
-
-	options := map[string]string{}
-
-	bus.Manager.Response(sdk.EventBeforeReset, func(p *pluggable.Plugin, r *pluggable.EventResponse) {
-		err := json.Unmarshal([]byte(r.Data), &options)
-		if err != nil {
-			fmt.Println(err)
-		}
-	})
 
 	cmd.PrintBranding(DefaultBanner)
 
-	// This loads yet another config ¬_¬
-	// TODO: merge this somehow with the rest so there is no 5 places to configure stuff?
+	// This config is only for reset branding.
 	agentConfig, err := LoadConfig()
 	if err != nil {
 		return err
@@ -71,6 +58,17 @@ func Reset(dir ...string) error {
 
 	ensureDataSourceReady()
 
+	optionsFromEvent := map[string]string{}
+
+	// This gets the options from an event that can be sent by anyone.
+	// This should override the default config as it's much more dynamic
+	bus.Manager.Response(sdk.EventBeforeReset, func(p *pluggable.Plugin, r *pluggable.EventResponse) {
+		err := json.Unmarshal([]byte(r.Data), &optionsFromEvent)
+		if err != nil {
+			fmt.Println(err)
+		}
+	})
+
 	bus.Manager.Publish(sdk.EventBeforeReset, sdk.EventPayload{}) //nolint:errcheck
 
 	c, err := config.Scan(collector.Directories(dir...))
@@ -86,12 +84,17 @@ func Reset(dir ...string) error {
 		return err
 	}
 
-	// Not even sure what opts can come from here to be honest. Where is the struct that supports this options?
-	// Where is the docs to support this? This is generic af and not easily identifiable
-	if len(options) == 0 {
-		resetSpec.FormatPersistent = true
-	} else {
-		fmt.Println(options)
+	// Go over the possible options sent via event
+	if len(optionsFromEvent) > 0 {
+		if p := optionsFromEvent["reset-persistent"]; p != "" {
+			resetSpec.FormatPersistent = p == "true"
+		}
+		if o := optionsFromEvent["reset-oem"]; o != "" {
+			resetSpec.FormatOEM = o == "true"
+		}
+		if s := optionsFromEvent["strict"]; s != "" {
+			resetConfig.Strict = s == "true"
+		}
 	}
 
 	resetAction := action.NewResetAction(resetConfig, resetSpec)

--- a/pkg/elementalConfig/config.go
+++ b/pkg/elementalConfig/config.go
@@ -495,12 +495,13 @@ func NewResetSpec(cfg v1.Config) (*v1.ResetSpec, error) {
 
 	activeFile := filepath.Join(ep.State.MountPoint, "cOS", constants.ActiveImgFile)
 	return &v1.ResetSpec{
-		Target:       target,
-		Partitions:   ep,
-		Efi:          efiExists,
-		GrubDefEntry: constants.GrubDefEntry,
-		GrubConf:     constants.GrubConf,
-		Tty:          constants.DefaultTty,
+		Target:           target,
+		Partitions:       ep,
+		Efi:              efiExists,
+		GrubDefEntry:     constants.GrubDefEntry,
+		GrubConf:         constants.GrubConf,
+		Tty:              constants.DefaultTty,
+		FormatPersistent: true,
 		Active: v1.Image{
 			Label:      constants.ActiveLabel,
 			Size:       constants.ImgSize,


### PR DESCRIPTION
Otherwise we have 2 different sources for the cloud-config options and we have no idea what to do with them.

This patch extract the 3 different config options that we are able to
override and sets them before running the reset

Should fix https://github.com/kairos-io/kairos/issues/1626

cc @santhoshdaivajna this would change the way you send the data a bit.

Instead of sending the option and an empty value for it you need to explicitly set the value of the option to either true or false.

Any empty values would be ignored.
Any other keys would be ignored.
Any values that differ from true/false would be ignored.
Default values for the reset spec should be good, we should not need to override anything.

so instead of sending:

```
response, _ := json.Marshal(map[string]string{
		"strict":           "",
		"reset-persistent": "",
		"system.uri":       "dir:/",
	})
```

you would send:

```
response, _ := json.Marshal(map[string]string{
		"strict":           "false",
		"reset-persistent": "true",
		"reset-oem":       "false",
	})
```


Notice that we only allow 3 options to be override:

 - reset-persistent -> True by default, would format the persistent partition
 - reset-oem -> False by default, would format the oem partition
 - strict -> False by default, would fail during cloud-config stages (before-reset, after-reset-chroot, after-reset) if any issues are encountered


We believe that the default values since 2.0.0 are in a sane state, so you can also drop and not send anything. Persistent should be formatted during a reset so you get a clena node, oem should be kept as it has configuration files for the system and strict should be disabled as there can always be minor issues in the default cloud-config file shipped with the system (there is actually a couple of issues already which we have no fix for for now)