### PR TITLE
Drop runconfig in favour of config

### DIFF
--- a/internal/agent/hooks/runstage.go
+++ b/internal/agent/hooks/runstage.go
@@ -16,7 +16,7 @@ func (r RunStage) Run(c config.Config, _ v1.Spec) error {
 	if err != nil {
 		cfg.Logger.Errorf("Error reading config: %s\n", err)
 	}
-	_ = utils.RunStage(&cfg.Config, "kairos-install.after", cfg.Strict, cfg.CloudInitPaths...)
+	_ = utils.RunStage(cfg, "kairos-install.after", cfg.Strict, cfg.CloudInitPaths...)
 	events.RunHookScript("/usr/bin/kairos-agent.install.after.hook") //nolint:errcheck
 	return nil
 }

--- a/internal/agent/hooks/runstage.go
+++ b/internal/agent/hooks/runstage.go
@@ -16,7 +16,7 @@ func (r RunStage) Run(c config.Config, _ v1.Spec) error {
 	if err != nil {
 		cfg.Logger.Errorf("Error reading config: %s\n", err)
 	}
-	_ = utils.RunStage(cfg, "kairos-install.after", cfg.Strict, cfg.CloudInitPaths...)
+	_ = utils.RunStage(cfg, "kairos-install.after")
 	events.RunHookScript("/usr/bin/kairos-agent.install.after.hook") //nolint:errcheck
 	return nil
 }

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -270,7 +270,7 @@ func RunInstall(c *config.Config) error {
 	installConfig.CloudInitPaths = append(installConfig.CloudInitPaths, installSpec.CloudInit...)
 
 	// Run pre-install stage
-	_ = elementalUtils.RunStage(installConfig, "kairos-install.pre", installConfig.Strict, installConfig.CloudInitPaths...)
+	_ = elementalUtils.RunStage(installConfig, "kairos-install.pre")
 	events.RunHookScript("/usr/bin/kairos-agent.install.pre.hook") //nolint:errcheck
 	// Create the action
 	installAction := action.NewInstallAction(installConfig, installSpec)

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -270,7 +270,7 @@ func RunInstall(c *config.Config) error {
 	installConfig.CloudInitPaths = append(installConfig.CloudInitPaths, installSpec.CloudInit...)
 
 	// Run pre-install stage
-	_ = elementalUtils.RunStage(&installConfig.Config, "kairos-install.pre", installConfig.Strict, installConfig.CloudInitPaths...)
+	_ = elementalUtils.RunStage(installConfig, "kairos-install.pre", installConfig.Strict, installConfig.CloudInitPaths...)
 	events.RunHookScript("/usr/bin/kairos-agent.install.pre.hook") //nolint:errcheck
 	// Create the action
 	installAction := action.NewInstallAction(installConfig, installSpec)

--- a/main.go
+++ b/main.go
@@ -544,7 +544,7 @@ The validate command expects a configuration file as its only argument. Local fi
 			if err != nil {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
 			}
-			return utils.RunStage(&cfg.Config, stage, cfg.Strict, cfg.CloudInitPaths...)
+			return utils.RunStage(cfg, stage)
 		},
 	},
 	{

--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -23,19 +23,19 @@ import (
 
 // Hook is RunStage wrapper that only adds logic to ignore errors
 // in case v1.Config.Strict is set to false
-func Hook(config *v1.Config, hook string, strict bool, cloudInitPaths ...string) error {
+func Hook(config *v1.Config, hook string) error {
 	config.Logger.Infof("Running %s hook", hook)
-	err := utils.RunStage(config, hook, strict, cloudInitPaths...)
-	if !strict {
+	err := utils.RunStage(config, hook)
+	if !config.Strict {
 		err = nil
 	}
 	return err
 }
 
 // ChrootHook executes Hook inside a chroot environment
-func ChrootHook(config *v1.Config, hook string, strict bool, chrootDir string, bindMounts map[string]string, cloudInitPaths ...string) (err error) {
+func ChrootHook(config *v1.Config, hook string, chrootDir string, bindMounts map[string]string) (err error) {
 	callback := func() error {
-		return Hook(config, hook, strict, cloudInitPaths...)
+		return Hook(config, hook)
 	}
 	return utils.ChrootedCallback(config, chrootDir, bindMounts, callback)
 }

--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Hook is RunStage wrapper that only adds logic to ignore errors
-// in case v1.RunConfig.Strict is set to false
+// in case v1.Config.Strict is set to false
 func Hook(config *v1.Config, hook string, strict bool, cloudInitPaths ...string) error {
 	config.Logger.Infof("Running %s hook", hook)
 	err := utils.RunStage(config, hook, strict, cloudInitPaths...)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -38,9 +38,9 @@ func (i *InstallAction) installHook(hook string, chroot bool) error {
 		if oem != nil && oem.MountPoint != "" {
 			extraMounts[oem.MountPoint] = cnst.OEMPath
 		}
-		return ChrootHook(i.cfg, hook, i.cfg.Strict, i.spec.Active.MountPoint, extraMounts, i.cfg.CloudInitPaths...)
+		return ChrootHook(i.cfg, hook, i.spec.Active.MountPoint, extraMounts)
 	}
-	return Hook(i.cfg, hook, i.cfg.Strict, i.cfg.CloudInitPaths...)
+	return Hook(i.cfg, hook)
 }
 
 func (i *InstallAction) createInstallStateYaml(sysMeta, recMeta interface{}) error {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -38,9 +38,9 @@ func (i *InstallAction) installHook(hook string, chroot bool) error {
 		if oem != nil && oem.MountPoint != "" {
 			extraMounts[oem.MountPoint] = cnst.OEMPath
 		}
-		return ChrootHook(&i.cfg.Config, hook, i.cfg.Strict, i.spec.Active.MountPoint, extraMounts, i.cfg.CloudInitPaths...)
+		return ChrootHook(i.cfg, hook, i.cfg.Strict, i.spec.Active.MountPoint, extraMounts, i.cfg.CloudInitPaths...)
 	}
-	return Hook(&i.cfg.Config, hook, i.cfg.Strict, i.cfg.CloudInitPaths...)
+	return Hook(i.cfg, hook, i.cfg.Strict, i.cfg.CloudInitPaths...)
 }
 
 func (i *InstallAction) createInstallStateYaml(sysMeta, recMeta interface{}) error {
@@ -107,17 +107,17 @@ func (i *InstallAction) createInstallStateYaml(sysMeta, recMeta interface{}) err
 }
 
 type InstallAction struct {
-	cfg  *v1.RunConfig
+	cfg  *v1.Config
 	spec *v1.InstallSpec
 }
 
-func NewInstallAction(cfg *v1.RunConfig, spec *v1.InstallSpec) *InstallAction {
+func NewInstallAction(cfg *v1.Config, spec *v1.InstallSpec) *InstallAction {
 	return &InstallAction{cfg: cfg, spec: spec}
 }
 
 // InstallRun will install the system from a given configuration
 func (i InstallAction) Run() (err error) {
-	e := elemental.NewElemental(&i.cfg.Config)
+	e := elemental.NewElemental(i.cfg)
 	cleanup := utils.NewCleanStack()
 	defer func() { err = cleanup.Cleanup(err) }()
 
@@ -181,7 +181,7 @@ func (i InstallAction) Run() (err error) {
 		return err
 	}
 	// Install grub
-	grub := utils.NewGrub(&i.cfg.Config)
+	grub := utils.NewGrub(i.cfg)
 	err = grub.Install(
 		i.spec.Target,
 		i.spec.Active.MountPoint,
@@ -197,14 +197,14 @@ func (i InstallAction) Run() (err error) {
 
 	// Relabel SELinux
 	binds := map[string]string{}
-	if mnt, _ := utils.IsMounted(&i.cfg.Config, i.spec.Partitions.Persistent); mnt {
+	if mnt, _ := utils.IsMounted(i.cfg, i.spec.Partitions.Persistent); mnt {
 		binds[i.spec.Partitions.Persistent.MountPoint] = cnst.UsrLocalPath
 	}
-	if mnt, _ := utils.IsMounted(&i.cfg.Config, i.spec.Partitions.OEM); mnt {
+	if mnt, _ := utils.IsMounted(i.cfg, i.spec.Partitions.OEM); mnt {
 		binds[i.spec.Partitions.OEM.MountPoint] = cnst.OEMPath
 	}
 	err = utils.ChrootedCallback(
-		&i.cfg.Config, i.spec.Active.MountPoint, binds, func() error { return e.SelinuxRelabel("/", true) },
+		i.cfg, i.spec.Active.MountPoint, binds, func() error { return e.SelinuxRelabel("/", true) },
 	)
 	if err != nil {
 		return err

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -42,7 +42,7 @@ const partTmpl = `
 %d:%ss:%ss:2048s:ext4::type=83;`
 
 var _ = Describe("Install action tests", func() {
-	var config *v1.RunConfig
+	var config *v1.Config
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS
 	var logger v1.Logger
@@ -69,7 +69,7 @@ var _ = Describe("Install action tests", func() {
 		Expect(err).Should(BeNil())
 
 		cloudInit = &v1mock.FakeCloudInitRunner{}
-		config = conf.NewRunConfig(
+		config = conf.NewConfig(
 			conf.WithFs(fs),
 			conf.WithRunner(runner),
 			conf.WithLogger(logger),
@@ -146,7 +146,7 @@ var _ = Describe("Install action tests", func() {
 			err = utils.MkdirAll(fs, constants.IsoBaseTree, constants.DirPerm)
 			Expect(err).To(BeNil())
 
-			spec = conf.NewInstallSpec(config.Config)
+			spec = conf.NewInstallSpec(config)
 			spec.Active.Size = 16
 
 			grubCfg := filepath.Join(spec.Active.MountPoint, constants.GrubConf)

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -38,9 +38,9 @@ func (r *ResetAction) resetHook(hook string, chroot bool) error {
 		if oem != nil && oem.MountPoint != "" {
 			extraMounts[oem.MountPoint] = cnst.OEMPath
 		}
-		return ChrootHook(r.cfg, hook, r.cfg.Strict, r.spec.Active.MountPoint, extraMounts, r.cfg.CloudInitPaths...)
+		return ChrootHook(r.cfg, hook, r.spec.Active.MountPoint, extraMounts)
 	}
-	return Hook(r.cfg, hook, r.cfg.Strict, r.cfg.CloudInitPaths...)
+	return Hook(r.cfg, hook)
 }
 
 type ResetAction struct {

--- a/pkg/action/reset_test.go
+++ b/pkg/action/reset_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 var _ = Describe("Reset action tests", func() {
-	var config *v1.RunConfig
+	var config *v1.Config
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS
 	var logger v1.Logger
@@ -63,7 +63,7 @@ var _ = Describe("Reset action tests", func() {
 		Expect(err).Should(BeNil())
 
 		cloudInit = &v1mock.FakeCloudInitRunner{}
-		config = conf.NewRunConfig(
+		config = conf.NewConfig(
 			conf.WithFs(fs),
 			conf.WithRunner(runner),
 			conf.WithLogger(logger),
@@ -140,7 +140,7 @@ var _ = Describe("Reset action tests", func() {
 				}
 			}
 
-			spec, err = conf.NewResetSpec(config.Config)
+			spec, err = conf.NewResetSpec(config)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(spec.Active.Source.IsEmpty()).To(BeFalse())
 

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -52,21 +52,21 @@ func (u UpgradeAction) Error(s string, args ...interface{}) {
 func (u UpgradeAction) upgradeHook(hook string, chroot bool) error {
 	u.Info("Applying '%s' hook", hook)
 	if chroot {
-		mountPoints := map[string]string{}
+		extraMounts := map[string]string{}
 
 		oemDevice := u.spec.Partitions.OEM
 		if oemDevice != nil && oemDevice.MountPoint != "" {
-			mountPoints[oemDevice.MountPoint] = constants.OEMPath
+			extraMounts[oemDevice.MountPoint] = constants.OEMPath
 		}
 
 		persistentDevice := u.spec.Partitions.Persistent
 		if persistentDevice != nil && persistentDevice.MountPoint != "" {
-			mountPoints[persistentDevice.MountPoint] = constants.UsrLocalPath
+			extraMounts[persistentDevice.MountPoint] = constants.UsrLocalPath
 		}
 
-		return ChrootHook(u.config, hook, u.config.Strict, u.spec.Active.MountPoint, mountPoints, u.config.CloudInitPaths...)
+		return ChrootHook(u.config, hook, u.spec.Active.MountPoint, extraMounts)
 	}
-	return Hook(u.config, hook, u.config.Strict, u.config.CloudInitPaths...)
+	return Hook(u.config, hook)
 }
 
 func (u *UpgradeAction) upgradeInstallStateYaml(meta interface{}, img v1.Image) error {

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 var _ = Describe("Runtime Actions", func() {
-	var config *v1.RunConfig
+	var config *v1.Config
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS
 	var logger v1.Logger
@@ -63,7 +63,7 @@ var _ = Describe("Runtime Actions", func() {
 		Expect(err).Should(BeNil())
 
 		cloudInit = &v1mock.FakeCloudInitRunner{}
-		config = conf.NewRunConfig(
+		config = conf.NewConfig(
 			conf.WithFs(fs),
 			conf.WithRunner(runner),
 			conf.WithLogger(logger),
@@ -143,7 +143,7 @@ var _ = Describe("Runtime Actions", func() {
 		Describe(fmt.Sprintf("Booting from %s", constants.ActiveLabel), Label("active_label"), func() {
 			var err error
 			BeforeEach(func() {
-				spec, err = conf.NewUpgradeSpec(config.Config)
+				spec, err = conf.NewUpgradeSpec(config)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = utils.MkdirAll(config.Fs, filepath.Join(spec.Active.MountPoint, "etc"), constants.DirPerm)
@@ -346,7 +346,7 @@ var _ = Describe("Runtime Actions", func() {
 		Describe(fmt.Sprintf("Booting from %s", constants.PassiveLabel), Label("passive_label"), func() {
 			var err error
 			BeforeEach(func() {
-				spec, err = conf.NewUpgradeSpec(config.Config)
+				spec, err = conf.NewUpgradeSpec(config)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = utils.MkdirAll(config.Fs, filepath.Join(spec.Active.MountPoint, "etc"), constants.DirPerm)
@@ -428,7 +428,7 @@ var _ = Describe("Runtime Actions", func() {
 					err = fs.WriteFile(recoveryImgSquash, []byte("recovery"), constants.FilePerm)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					spec, err = conf.NewUpgradeSpec(config.Config)
+					spec, err = conf.NewUpgradeSpec(config)
 					Expect(err).ShouldNot(HaveOccurred())
 					spec.Active.Size = 10
 					spec.Passive.Size = 10
@@ -513,7 +513,7 @@ var _ = Describe("Runtime Actions", func() {
 					err = fs.WriteFile(recoveryImg, []byte("recovery"), constants.FilePerm)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					spec, err = conf.NewUpgradeSpec(config.Config)
+					spec, err = conf.NewUpgradeSpec(config)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					spec.Active.Size = 10

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -522,7 +522,7 @@ func (e Elemental) UpdateSourcesFormDownloadedISO(workDir string, activeImg *v1.
 	return nil
 }
 
-// SetDefaultGrubEntry Sets the default_meny_entry value in RunConfig.GrubOEMEnv file at in
+// SetDefaultGrubEntry Sets the default_meny_entry value in Config.GrubOEMEnv file at in
 // State partition mountpoint. If there is not a custom value in the os-release file, we do nothing
 // As the grub config already has a sane default
 func (e Elemental) SetDefaultGrubEntry(partMountPoint string, imgMountPoint string, defaultEntry string) error {

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -341,7 +341,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			cInit = &v1mock.FakeCloudInitRunner{ExecStages: []string{}, Error: false}
 			config.CloudInitRunner = cInit
 			el = elemental.NewElemental(config)
-			install = conf.NewInstallSpec(*config)
+			install = conf.NewInstallSpec(config)
 			install.Target = "/some/device"
 
 			err := utils.MkdirAll(fs, "/some", cnst.DirPerm)

--- a/pkg/elementalConfig/config_test.go
+++ b/pkg/elementalConfig/config_test.go
@@ -124,8 +124,8 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(c.Mounter).To(Equal(mount.New(constants.MountBinary)))
 			})
 		})
-		Describe("RunConfig", func() {
-			cfg := elementalConfig.NewRunConfig(elementalConfig.WithMounter(mounter))
+		Describe("Config", func() {
+			cfg := elementalConfig.NewConfig(elementalConfig.WithMounter(mounter))
 			Expect(cfg.Mounter).To(Equal(mounter))
 			Expect(cfg.Runner).NotTo(BeNil())
 		})
@@ -150,7 +150,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				_, err = fs.Create(recoveryImgFile)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				spec := elementalConfig.NewInstallSpec(*c)
+				spec := elementalConfig.NewInstallSpec(c)
 				Expect(spec.Firmware).To(Equal(v1.EFI))
 				Expect(spec.Active.Source.Value()).To(Equal(constants.IsoBaseTree))
 				Expect(spec.Recovery.Source.Value()).To(Equal(recoveryImgFile))
@@ -171,7 +171,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				_, err = fs.Create(constants.IsoBaseTree)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				spec := elementalConfig.NewInstallSpec(*c)
+				spec := elementalConfig.NewInstallSpec(c)
 				Expect(spec.Firmware).To(Equal(v1.BIOS))
 				Expect(spec.Active.Source.Value()).To(Equal(constants.IsoBaseTree))
 				Expect(spec.Recovery.Source.Value()).To(Equal(spec.Active.File))
@@ -186,7 +186,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(spec.Partitions.BIOS).NotTo(BeNil())
 			})
 			It("sets installation defaults without being on installation media", Label("install"), func() {
-				spec := elementalConfig.NewInstallSpec(*c)
+				spec := elementalConfig.NewInstallSpec(c)
 				Expect(spec.Firmware).To(Equal(v1.BIOS))
 				Expect(spec.Active.Source.IsEmpty()).To(BeTrue())
 				Expect(spec.Recovery.Source.Value()).To(Equal(spec.Active.File))
@@ -256,7 +256,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					_, err = fs.Create(constants.IsoBaseTree)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					spec, err := elementalConfig.NewResetSpec(*c)
+					spec, err := elementalConfig.NewResetSpec(c)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(spec.Active.Source.Value()).To(Equal(constants.IsoBaseTree))
 					Expect(spec.Partitions.EFI.MountPoint).To(Equal(constants.EfiDir))
@@ -269,12 +269,12 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					_, err = fs.Create(recoveryImg)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					spec, err := elementalConfig.NewResetSpec(*c)
+					spec, err := elementalConfig.NewResetSpec(c)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(spec.Active.Source.Value()).To(Equal(recoveryImg))
 				})
 				It("sets reset defaults on bios from unknown recovery", func() {
-					spec, err := elementalConfig.NewResetSpec(*c)
+					spec, err := elementalConfig.NewResetSpec(c)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(spec.Active.Source.IsEmpty()).To(BeTrue())
 				})
@@ -312,13 +312,13 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					ghwTest.Clean()
 				})
 				It("fails to set defaults if not booted from recovery", func() {
-					_, err := elementalConfig.NewResetSpec(*c)
+					_, err := elementalConfig.NewResetSpec(c)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("reset can only be called from the recovery system"))
 				})
 				It("fails to set defaults if no recovery partition detected", func() {
 					bootedFrom = constants.SystemLabel
-					_, err := elementalConfig.NewResetSpec(*c)
+					_, err := elementalConfig.NewResetSpec(c)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("recovery partition not found"))
 				})
@@ -333,7 +333,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					defer ghwTest.Clean()
 
 					bootedFrom = constants.SystemLabel
-					_, err := elementalConfig.NewResetSpec(*c)
+					_, err := elementalConfig.NewResetSpec(c)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("state partition not found"))
 				})
@@ -345,7 +345,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					bootedFrom = constants.SystemLabel
-					_, err := elementalConfig.NewResetSpec(*c)
+					_, err := elementalConfig.NewResetSpec(c)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("EFI partition not found"))
 				})
@@ -394,12 +394,12 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					ghwTest.Clean()
 				})
 				It("sets upgrade defaults for active upgrade", func() {
-					spec, err := elementalConfig.NewUpgradeSpec(*c)
+					spec, err := elementalConfig.NewUpgradeSpec(c)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(spec.Active.Source.IsEmpty()).To(BeTrue())
 				})
 				It("sets upgrade defaults for non-squashed recovery upgrade", func() {
-					spec, err := elementalConfig.NewUpgradeSpec(*c)
+					spec, err := elementalConfig.NewUpgradeSpec(c)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(spec.Recovery.Source.IsEmpty()).To(BeTrue())
 					Expect(spec.Recovery.FS).To(Equal(constants.LinuxImgFs))
@@ -413,7 +413,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					_, err = fs.Create(img)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					spec, err := elementalConfig.NewUpgradeSpec(*c)
+					spec, err := elementalConfig.NewUpgradeSpec(c)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(spec.Recovery.Source.IsEmpty()).To(BeTrue())
 					Expect(spec.Recovery.FS).To(Equal(constants.SquashFs))
@@ -512,14 +512,14 @@ cloud-init-paths:
 			It("Reads properly the cloud config for reset", func() {
 				bootedFrom = constants.SystemLabel
 				cfg, err := config.Scan(collector.Directories([]string{dir}...), collector.NoLogs)
-				runconfig, err := elementalConfig.ReadConfigRunFromAgentConfig(cfg)
+				config, err := elementalConfig.ReadConfigRunFromAgentConfig(cfg)
 				Expect(err).ToNot(HaveOccurred())
-				// Override the runconfig with our test params
-				runconfig.Runner = runner
-				runconfig.Fs = fs
-				runconfig.Mounter = mounter
-				runconfig.CloudInitRunner = ci
-				spec, err := elementalConfig.ReadSpecFromCloudConfig(runconfig, "reset")
+				// Override the config with our test params
+				config.Runner = runner
+				config.Fs = fs
+				config.Mounter = mounter
+				config.CloudInitRunner = ci
+				spec, err := elementalConfig.ReadSpecFromCloudConfig(config, "reset")
 				Expect(err).ToNot(HaveOccurred())
 				resetSpec := spec.(*v1.ResetSpec)
 				Expect(resetSpec.FormatPersistent).To(BeTrue())
@@ -528,23 +528,23 @@ cloud-init-paths:
 			})
 			It("Reads properly the cloud config for upgrade", func() {
 				cfg, err := config.Scan(collector.Directories([]string{dir}...), collector.NoLogs)
-				runconfig, err := elementalConfig.ReadConfigRunFromAgentConfig(cfg)
+				config, err := elementalConfig.ReadConfigRunFromAgentConfig(cfg)
 				Expect(err).ToNot(HaveOccurred())
-				// Override the runconfig with our test params
-				runconfig.Runner = runner
-				runconfig.Fs = fs
-				runconfig.Mounter = mounter
-				runconfig.CloudInitRunner = ci
-				spec, err := elementalConfig.ReadSpecFromCloudConfig(runconfig, "upgrade")
+				// Override the config with our test params
+				config.Runner = runner
+				config.Fs = fs
+				config.Mounter = mounter
+				config.CloudInitRunner = ci
+				spec, err := elementalConfig.ReadSpecFromCloudConfig(config, "upgrade")
 				Expect(err).ToNot(HaveOccurred())
 				upgradeSpec := spec.(*v1.UpgradeSpec)
 				Expect(upgradeSpec.RecoveryUpgrade).To(BeTrue())
 			})
 			It("Fails when a wrong action is read", func() {
 				cfg, err := config.Scan(collector.Directories([]string{dir}...), collector.NoLogs)
-				runconfig, err := elementalConfig.ReadConfigRunFromAgentConfig(cfg)
+				config, err := elementalConfig.ReadConfigRunFromAgentConfig(cfg)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = elementalConfig.ReadSpecFromCloudConfig(runconfig, "nope")
+				_, err = elementalConfig.ReadSpecFromCloudConfig(config, "nope")
 				Expect(err).To(HaveOccurred())
 			})
 			It("Sets info level if its not on the cloud-config", func() {

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -46,6 +46,11 @@ type Spec interface {
 // Config is the struct that includes basic and generic configuration of elemental binary runtime.
 // It mostly includes the interfaces used around many methods in elemental code
 type Config struct {
+	Debug                     bool     `yaml:"debug,omitempty" mapstructure:"debug"`
+	Strict                    bool     `yaml:"strict,omitempty" mapstructure:"strict"`
+	CloudInitPaths            []string `yaml:"cloud-init-paths,omitempty" mapstructure:"cloud-init-paths"`
+	EjectCD                   bool     `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
+	FullCloudConfig           string   // Stores the full cloud config used to generate the spec afterwards
 	Logger                    Logger
 	Fs                        FS
 	Mounter                   mount.Interface
@@ -124,24 +129,6 @@ func (c *Config) Sanitize() error {
 		c.Platform = p
 	}
 	return nil
-}
-
-type RunConfig struct {
-	Debug           bool     `yaml:"debug,omitempty" mapstructure:"debug"`
-	Strict          bool     `yaml:"strict,omitempty" mapstructure:"strict"`
-	CloudInitPaths  []string `yaml:"cloud-init-paths,omitempty" mapstructure:"cloud-init-paths"`
-	EjectCD         bool     `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
-	FullCloudConfig string   // Stores the full cloud config used to generate the spec afterwards
-
-	// 'inline' and 'squash' labels ensure config fields
-	// are embedded from a yaml and map PoV
-	Config `yaml:",inline" mapstructure:",squash"`
-}
-
-// Sanitize checks the consistency of the struct, returns error
-// if unsolvable inconsistencies are found
-func (r *RunConfig) Sanitize() error {
-	return r.Config.Sanitize()
 }
 
 // InstallSpec struct represents all the installation action details

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -33,7 +33,7 @@ import (
 
 var _ = Describe("Types", Label("types", "config"), func() {
 	Describe("Write and load installation state", func() {
-		var config *v1.RunConfig
+		var config *v1.Config
 		var runner *v1mocks.FakeRunner
 		var fs vfs.FS
 		var mounter *v1mocks.ErrorMounter
@@ -49,7 +49,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{})
 			Expect(err).Should(BeNil())
 
-			config = conf.NewRunConfig(
+			config = conf.NewConfig(
 				conf.WithFs(fs),
 				conf.WithRunner(runner),
 				conf.WithMounter(mounter),
@@ -319,10 +319,10 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			Expect(p.GetByName("nonexistent")).To(BeNil())
 		})
 	})
-	Describe("RunConfig", func() {
+	Describe("Config", func() {
 		It("runs sanitize method", func() {
-			cfg := elementalConfig.NewRunConfig(elementalConfig.WithMounter(v1mocks.NewErrorMounter()))
-			cfg.Config.Verify = true
+			cfg := elementalConfig.NewConfig(elementalConfig.WithMounter(v1mocks.NewErrorMounter()))
+			cfg.Verify = true
 
 			err := cfg.Sanitize()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -333,7 +333,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 
 		BeforeEach(func() {
 			cfg := elementalConfig.NewConfig(elementalConfig.WithMounter(v1mocks.NewErrorMounter()))
-			spec = elementalConfig.NewInstallSpec(*cfg)
+			spec = elementalConfig.NewInstallSpec(cfg)
 		})
 		Describe("sanitize", func() {
 			It("runs method", func() {

--- a/pkg/utils/runstage.go
+++ b/pkg/utils/runstage.go
@@ -57,11 +57,12 @@ func checkYAMLError(cfg *v1.Config, allErrors, err error) error {
 }
 
 // RunStage will run yip
-func RunStage(cfg *v1.Config, stage string, strict bool, cloudInitPaths ...string) error {
+func RunStage(cfg *v1.Config, stage string) error {
 	var cmdLineYipURI string
 	var allErrors error
+	var cloudInitPaths []string
 
-	cloudInitPaths = append(constants.GetCloudInitPaths(), cloudInitPaths...)
+	cloudInitPaths = append(constants.GetCloudInitPaths(), cfg.CloudInitPaths...)
 	cfg.Logger.Debugf("Cloud-init paths set to %v", cloudInitPaths)
 
 	// Make sure cloud init path specified are existing in the system
@@ -126,7 +127,7 @@ func RunStage(cfg *v1.Config, stage string, strict bool, cloudInitPaths ...strin
 	// We return error here only if we have been running in strict mode.
 	// Cloud configs are being loaded and executed on a best-effort, so every step/config
 	// gets a chance to be executed and error is being appended and reported.
-	if allErrors != nil && !strict {
+	if allErrors != nil && !cfg.Strict {
 		cfg.Logger.Info("Some errors found but were ignored. Enable --strict mode to fail on those or --debug to see them in the log")
 		cfg.Logger.Warn(allErrors)
 		return nil

--- a/pkg/utils/runstage_test.go
+++ b/pkg/utils/runstage_test.go
@@ -51,10 +51,8 @@ var _ = Describe("run stage", Label("RunStage"), func() {
 	var memLog *bytes.Buffer
 
 	var cleanup func()
-	var strict bool
 
 	BeforeEach(func() {
-		strict = false
 		runner = v1mock.NewFakeRunner()
 		// Use a different config with a buffer for logger, so we can check the output
 		// We also use the real fs
@@ -80,15 +78,15 @@ var _ = Describe("run stage", Label("RunStage"), func() {
 		d, err := utils.TempDir(fs, "", "elemental")
 		Expect(err).ToNot(HaveOccurred())
 		_ = fs.WriteFile(fmt.Sprintf("%s/test.yaml", d), []byte("stages: [foo,bar]"), os.ModePerm)
-		strict = true
-		Expect(utils.RunStage(config, "c3po", strict, d)).ToNot(BeNil())
+		config.Strict = true
+		Expect(utils.RunStage(config, "c3po")).ToNot(BeNil())
 	})
 
 	It("does not fail but prints errors by default", Label("strict"), func() {
 		writeCmdline("stages.c3po[0].datasource", fs)
 
 		config.Logger.SetLevel(log.DebugLevel)
-		out := utils.RunStage(config, "c3po", strict)
+		out := utils.RunStage(config, "c3po")
 		Expect(out).To(BeNil())
 		Expect(memLog.String()).To(ContainSubstring("parsing returned errors"))
 	})
@@ -97,8 +95,9 @@ var _ = Describe("run stage", Label("RunStage"), func() {
 		d, err := utils.TempDir(fs, "", "elemental")
 		Expect(err).ToNot(HaveOccurred())
 		config.Logger.SetLevel(log.DebugLevel)
+		config.CloudInitPaths = []string{d}
 
-		Expect(utils.RunStage(config, "luke", strict, d)).To(BeNil())
+		Expect(utils.RunStage(config, "luke")).To(BeNil())
 		Expect(memLog.String()).To(ContainSubstring(d))
 		Expect(memLog).To(ContainSubstring("luke"))
 		Expect(memLog).To(ContainSubstring("luke.before"))
@@ -111,7 +110,7 @@ var _ = Describe("run stage", Label("RunStage"), func() {
 
 		writeCmdline(fmt.Sprintf("cos.setup=%s/test.yaml", d), fs)
 
-		Expect(utils.RunStage(config, "padme", strict)).To(BeNil())
+		Expect(utils.RunStage(config, "padme")).To(BeNil())
 		Expect(memLog).To(ContainSubstring("padme"))
 		Expect(memLog).To(ContainSubstring(fmt.Sprintf("%s/test.yaml", d)))
 	})
@@ -119,13 +118,13 @@ var _ = Describe("run stage", Label("RunStage"), func() {
 	It("parses cmdline uri with dotnotation", func() {
 		writeCmdline("stages.leia[0].commands[0]='echo beepboop'", fs)
 		config.Logger.SetLevel(log.DebugLevel)
-		Expect(utils.RunStage(config, "leia", strict)).To(BeNil())
+		Expect(utils.RunStage(config, "leia")).To(BeNil())
 		Expect(memLog).To(ContainSubstring("leia"))
 		Expect(memLog).To(ContainSubstring("running command `echo beepboop`"))
 
 		// try with a non-clean cmdline
 		writeCmdline("BOOT=death-star single stages.leia[0].commands[0]='echo beepboop'", fs)
-		Expect(utils.RunStage(config, "leia", strict)).To(BeNil())
+		Expect(utils.RunStage(config, "leia")).To(BeNil())
 		Expect(memLog).To(ContainSubstring("leia"))
 		Expect(memLog).To(ContainSubstring("running command `echo beepboop`"))
 		Expect(memLog.String()).ToNot(ContainSubstring("/proc/cmdline parsing returned errors while unmarshalling"))
@@ -135,7 +134,7 @@ var _ = Describe("run stage", Label("RunStage"), func() {
 	It("ignores YAML errors", func() {
 		config.Logger.SetLevel(log.DebugLevel)
 		writeCmdline("BOOT=death-star sing1!~@$%6^&**le /varlib stag_#var<Lib stages[0]='utterly broken by breaking schema'", fs)
-		Expect(utils.RunStage(config, "leia", strict)).To(BeNil())
+		Expect(utils.RunStage(config, "leia")).To(BeNil())
 		Expect(memLog.String()).To(ContainSubstring("/proc/cmdline parsing returned errors while unmarshalling"))
 		Expect(memLog.String()).ToNot(ContainSubstring("Some errors found but were ignored. Enable --strict mode to fail on those or --debug to see them in the log"))
 	})


### PR DESCRIPTION
    As we no longer need different configs for both build stuff and run
    stuff we can merge back the runconfig into config, which will make it
    easier to merge it into the agentconfig


Signed-off-by: Itxaka <itxaka.garcia@spectrocloud.com>