### PR TITLE
Fix config loading, install device and call sanitize

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -117,7 +117,7 @@ func NewInstallAction(cfg *config.Config, spec *v1.InstallSpec) *InstallAction {
 	return &InstallAction{cfg: cfg, spec: spec}
 }
 
-// InstallRun will install the system from a given configuration
+// Run will install the system from a given configuration
 func (i InstallAction) Run() (err error) {
 	e := elemental.NewElemental(i.cfg)
 	cleanup := utils.NewCleanStack()

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	agentConfig "github.com/kairos-io/kairos-agent/v2/pkg/config"
 	"github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
+	"github.com/kairos-io/kairos-sdk/collector"
 	"path/filepath"
 	"regexp"
 
@@ -80,6 +81,9 @@ var _ = Describe("Install action tests", func() {
 			agentConfig.WithCloudInitRunner(cloudInit),
 			agentConfig.WithImageExtractor(extractor),
 		)
+		config.Install = &agentConfig.Install{}
+		config.Bundles = agentConfig.Bundles{}
+		config.Config = collector.Config{}
 	})
 
 	AfterEach(func() {
@@ -95,6 +99,7 @@ var _ = Describe("Install action tests", func() {
 
 		BeforeEach(func() {
 			device = "/some/device"
+			config.Install.Device = device
 			err = fsutils.MkdirAll(fs, filepath.Dir(device), constants.DirPerm)
 			Expect(err).To(BeNil())
 			_, err = fs.Create(device)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,6 +69,7 @@ func NewConfig(opts ...GenericOptions) *Config {
 		SquashFsCompressionConfig: constants.GetDefaultSquashfsCompressionOptions(),
 		ImageExtractor:            v1.OCIImageExtractor{},
 		SquashFsNoCompression:     true,
+		Install:                   &Install{},
 	}
 	for _, o := range opts {
 		o(c)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -126,7 +126,7 @@ type Config struct {
 	CloudInitRunner           v1.CloudInitRunner  `yaml:"-"`
 	ImageExtractor            v1.ImageExtractor   `yaml:"-"`
 	Client                    v1.HTTPClient       `yaml:"-"`
-	Platform                  *v1.Platform        `yaml:"platform,omitempty" mapstructure:"platform"`
+	Platform                  *v1.Platform        `yaml:"-"`
 	Cosign                    bool                `yaml:"cosign,omitempty" mapstructure:"cosign"`
 	Verify                    bool                `yaml:"verify,omitempty" mapstructure:"verify"`
 	CosignPubKey              string              `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
@@ -180,7 +180,7 @@ func (c *Config) Sanitize() error {
 	if c.SquashFsNoCompression {
 		c.SquashFsCompressionConfig = []string{}
 	}
-	if c.Arch != "" {
+	if c.Arch != "" && c.Platform == nil {
 		p, err := v1.NewPlatformFromArch(c.Arch)
 		if err != nil {
 			return err

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -437,7 +437,7 @@ func ReadSpecFromCloudConfig(r *Config, spec string) (v1.Spec, error) {
 		r.Logger.Warnf("Error sanitizing the % spec: %s", spec, err)
 	}
 	r.Logger.Debugf("Loaded %s spec: %s", litter.Sdump(sp))
-	return sp, err
+	return sp, nil
 }
 
 func configLogger(log v1.Logger, vfs v1.FS) {

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -86,6 +86,7 @@ func NewInstallSpec(cfg *Config) *v1.InstallSpec {
 	}
 
 	return &v1.InstallSpec{
+		Target:     cfg.Install.Device,
 		Firmware:   firmware,
 		PartTable:  v1.GPT,
 		Partitions: NewInstallElementalPartitions(),
@@ -430,6 +431,10 @@ func ReadSpecFromCloudConfig(r *Config, spec string) (v1.Spec, error) {
 	err = vp.Unmarshal(sp, setDecoder, decodeHook)
 	if err != nil {
 		r.Logger.Warnf("error unmarshalling %s Spec: %s", spec, err)
+	}
+	err = sp.Sanitize()
+	if err != nil {
+		r.Logger.Warnf("Error sanitizing the % spec: %s", spec, err)
 	}
 	r.Logger.Debugf("Loaded %s spec: %s", litter.Sdump(sp))
 	return sp, err

--- a/pkg/config/spec_test.go
+++ b/pkg/config/spec_test.go
@@ -67,6 +67,10 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				config.WithClient(client),
 				config.WithPlatform("linux/arm64"),
 			)
+			c.Install = &config.Install{}
+			c.Bundles = config.Bundles{}
+			c.Config = collector.Config{}
+			fmt.Println(litter.Sdump(c))
 		})
 		AfterEach(func() {
 			cleanup()
@@ -442,6 +446,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				ccdata := []byte(`#cloud-config
 strict: true
 install:
+  device: /some/device
   grub-entry-name: "MyCustomOS"
   system:
     size: 666
@@ -502,7 +507,11 @@ cloud-init-paths:
 			It("Reads properly the cloud config for install", func() {
 				cfg, err := config.Scan(collector.Directories([]string{dir}...), collector.NoLogs)
 				Expect(err).ToNot(HaveOccurred())
-				fmt.Print(litter.Sdump(cfg))
+				// Once we got the cfg override the fs to our test fs
+				cfg.Runner = runner
+				cfg.Fs = fs
+				cfg.Mounter = mounter
+				cfg.CloudInitRunner = ci
 				installSpec, err := config.ReadInstallSpecFromConfig(cfg)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cfg.Strict).To(BeTrue())

--- a/pkg/config/spec_test.go
+++ b/pkg/config/spec_test.go
@@ -447,6 +447,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 strict: true
 install:
   device: /some/device
+  skip_copy_kcrypt_plugin: true
   grub-entry-name: "MyCustomOS"
   system:
     size: 666
@@ -515,6 +516,9 @@ cloud-init-paths:
 				installSpec, err := config.ReadInstallSpecFromConfig(cfg)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cfg.Strict).To(BeTrue())
+				Expect(cfg.Install.SkipEncryptCopyPlugins).To(BeTrue())
+				Expect(cfg.Install.Device).To(Equal("/some/device"))
+				Expect(installSpec.Target).To(Equal("/some/device"))
 				Expect(installSpec.GrubDefEntry).To(Equal("MyCustomOS"))
 				Expect(installSpec.Active.Size).To(Equal(uint(666)))
 				Expect(cfg.CloudInitPaths).To(ContainElement("/what"))

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -341,6 +341,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		BeforeEach(func() {
 			cInit = &v1mock.FakeCloudInitRunner{ExecStages: []string{}, Error: false}
 			config.CloudInitRunner = cInit
+			config.Install.Device = "/some/device"
 			el = elemental.NewElemental(config)
 			install = agentConfig.NewInstallSpec(config)
 			install.Target = "/some/device"


### PR DESCRIPTION
Syncs the cfg.install.device to the installspec.target As on manual-install the device can actually come from a flag and its not on the cloud-config, we need to initialize the InstallSpec with the value of the cfg.Install.Device as by that time we already have the final value of the install target.

Also calls sanitize on config and specs and warns if anything goes wrong