### PR TITLE
Drop logrusWrapper

### DIFF
--- a/pkg/types/v1/logger.go
+++ b/pkg/types/v1/logger.go
@@ -18,12 +18,8 @@ package v1
 
 import (
 	"bytes"
-	"fmt"
-	"io"
-	"regexp"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
+	"io"
 )
 
 // Logger is the interface we want for our logger, so we can plug different ones easily
@@ -33,7 +29,6 @@ type Logger interface {
 	Debug(...interface{})
 	Error(...interface{})
 	Fatal(...interface{})
-	Success(...interface{})
 	Warning(...interface{})
 	Panic(...interface{})
 	Trace(...interface{})
@@ -48,12 +43,6 @@ type Logger interface {
 	GetLevel() log.Level
 	SetOutput(writer io.Writer)
 	SetFormatter(formatter log.Formatter)
-
-	SetContext(string)
-	SpinnerStop()
-	Spinner()
-	Ask() bool
-	Screen(string)
 }
 
 func DebugLevel() log.Level {
@@ -65,97 +54,20 @@ func IsDebugLevel(l Logger) bool {
 	return l.GetLevel() == DebugLevel()
 }
 
-type LoggerOptions func(l Logger) error
-
 func NewLogger() Logger {
-	return newLogrusWrapper(log.New())
+	return log.New()
 }
 
 // NewNullLogger will return a logger that discards all logs, used mainly for testing
 func NewNullLogger() Logger {
 	logger := log.New()
 	logger.SetOutput(io.Discard)
-	return newLogrusWrapper(logger)
+	return logger
 }
 
 // NewBufferLogger will return a logger that stores all logs in a buffer, used mainly for testing
 func NewBufferLogger(b *bytes.Buffer) Logger {
 	logger := log.New()
 	logger.SetOutput(b)
-	return newLogrusWrapper(logger)
+	return logger
 }
-
-type logrusWrapper struct {
-	*log.Logger
-}
-
-func newLogrusWrapper(l *log.Logger) Logger {
-	return &logrusWrapper{Logger: l}
-}
-
-func (w *logrusWrapper) Ask() bool {
-	var input string
-	w.Info("Do you want to continue with this operation? [y/N]: ")
-	_, err := fmt.Scanln(&input)
-	if err != nil {
-		return false
-	}
-	input = strings.ToLower(input)
-
-	if input == "y" || input == "yes" {
-		return true
-	}
-	return false
-}
-
-func (w *logrusWrapper) Success(r ...interface{}) {
-	// Will redirect to the Info method below and be cleaned there
-	w.Info(r...)
-}
-
-var emojiStrip = regexp.MustCompile(`[:][\w]+[:]`)
-
-func (w *logrusWrapper) Debug(args ...interface{}) {
-	converted := convert(args)
-	w.Logger.Debug(converted)
-}
-
-func (w *logrusWrapper) Info(args ...interface{}) {
-	converted := convert(args)
-	w.Logger.Info(converted)
-}
-
-func (w *logrusWrapper) Warn(args ...interface{}) {
-	converted := convert(args)
-	w.Logger.Warn(converted)
-}
-
-func (w *logrusWrapper) Error(args ...interface{}) {
-	converted := convert(args)
-	w.Logger.Error(converted)
-}
-
-func (w *logrusWrapper) Fatal(args ...interface{}) {
-	converted := convert(args)
-	w.Logger.Fatal(converted)
-}
-
-// convert changes a list of interfaces into a proper joined string ready to log
-func convert(args []interface{}) string {
-	var together []string
-	// Matches a :WORD: and any extra space after that and the next word to remove emojis
-	// which are like ":house: realMessageStartsHere"
-	emojiStrip = regexp.MustCompile(`[:][\w]+[:]\s`)
-	for _, a := range args {
-		toClean := fmt.Sprintf("%v", a)                     // coerce into string
-		cleaned := emojiStrip.ReplaceAllString(toClean, "") // remove any emoji
-		trimmed := strings.Trim(cleaned, " ")               // trim any spaces in prefix/suffix
-		together = append(together, trimmed)
-	}
-	return strings.Join(together, " ") // return them nicely joined with spaces like a normal phrase
-}
-
-func (w *logrusWrapper) SetContext(string) {}
-func (w *logrusWrapper) Spinner()          {}
-func (w *logrusWrapper) SpinnerStop()      {}
-func (w *logrusWrapper) Screen(t string)   {}


### PR DESCRIPTION
The only reason this was there is to have compatibility with luet due to installing from channel sources.

Now that there is no channel sources, there is no point in having it anymore as its not used.