### PR TITLE
Allow creating dirs in rootfs via cc

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -19,7 +19,6 @@ package action
 import (
 	"fmt"
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
-	fsutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
 	"path/filepath"
 	"strings"
 	"time"
@@ -179,15 +178,7 @@ func (i InstallAction) Run() (err error) {
 	cleanup.Push(func() error { return e.UnmountImage(&i.spec.Active) })
 
 	// Create extra dirs in rootfs as afterwards this will be impossible due to RO system
-	for _, d := range i.spec.ExtraDirsRootfs {
-		if exists, _ := fsutils.Exists(i.cfg.Fs, filepath.Join(i.spec.Active.MountPoint, d)); !exists {
-			i.cfg.Logger.Debugf("Creating extra dir %s under %s", d, i.spec.Active.MountPoint)
-			err = i.cfg.Fs.Mkdir(filepath.Join(i.spec.Active.MountPoint, d), cnst.DirPerm)
-			if err != nil {
-				i.cfg.Logger.Warnf("Failure creating extra dir %s in rootfs at %s", d, i.spec.Active.MountPoint)
-			}
-		}
-	}
+	createExtraDirsInRootfs(i.cfg, i.spec.ExtraDirsRootfs, i.spec.Active.MountPoint)
 
 	// Copy cloud-init if any
 	err = e.CopyCloudConfig(i.spec.CloudInit)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -19,6 +19,7 @@ package action
 import (
 	"fmt"
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
+	fsutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
 	"path/filepath"
 	"strings"
 	"time"
@@ -176,6 +177,17 @@ func (i InstallAction) Run() (err error) {
 		return err
 	}
 	cleanup.Push(func() error { return e.UnmountImage(&i.spec.Active) })
+
+	// Create extra dirs in rootfs as afterwards this will be impossible due to RO system
+	for _, d := range i.spec.ExtraDirsRootfs {
+		if exists, _ := fsutils.Exists(i.cfg.Fs, filepath.Join(i.spec.Active.MountPoint, d)); !exists {
+			i.cfg.Logger.Debugf("Creating extra dir %s under %s", d, i.spec.Active.MountPoint)
+			err = i.cfg.Fs.Mkdir(filepath.Join(i.spec.Active.MountPoint, d), cnst.DirPerm)
+			if err != nil {
+				i.cfg.Logger.Warnf("Failure creating extra dir %s in rootfs at %s", d, i.spec.Active.MountPoint)
+			}
+		}
+	}
 
 	// Copy cloud-init if any
 	err = e.CopyCloudConfig(i.spec.CloudInit)

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -19,7 +19,6 @@ package action
 import (
 	"fmt"
 	agentConfig "github.com/kairos-io/kairos-agent/v2/pkg/config"
-	fsutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
 	"path/filepath"
 	"time"
 
@@ -170,15 +169,7 @@ func (r ResetAction) Run() (err error) {
 	cleanup.Push(func() error { return e.UnmountImage(&r.spec.Active) })
 
 	// Create extra dirs in rootfs as afterwards this will be impossible due to RO system
-	for _, d := range r.spec.ExtraDirsRootfs {
-		if exists, _ := fsutils.Exists(r.cfg.Fs, filepath.Join(r.spec.Active.MountPoint, d)); !exists {
-			r.cfg.Logger.Debugf("Creating extra dir %s under %s", d, r.spec.Active.MountPoint)
-			err = r.cfg.Fs.Mkdir(filepath.Join(r.spec.Active.MountPoint, d), cnst.DirPerm)
-			if err != nil {
-				r.cfg.Logger.Warnf("Failure creating extra dir %s in rootfs at %s", d, r.spec.Active.MountPoint)
-			}
-		}
-	}
+	createExtraDirsInRootfs(r.cfg, r.spec.ExtraDirsRootfs, r.spec.Active.MountPoint)
 
 	// install grub
 	grub := utils.NewGrub(r.cfg)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -182,15 +182,7 @@ func (u *UpgradeAction) Run() (err error) {
 	cleanup.Push(func() error { return e.UnmountImage(&upgradeImg) })
 
 	// Create extra dirs in rootfs as afterwards this will be impossible due to RO system
-	for _, d := range u.spec.ExtraDirsRootfs {
-		if exists, _ := fsutils.Exists(u.config.Fs, filepath.Join(upgradeImg.MountPoint, d)); !exists {
-			u.config.Logger.Debugf("Creating extra dir %s under %s", d, upgradeImg.MountPoint)
-			err = u.config.Fs.Mkdir(filepath.Join(upgradeImg.MountPoint, d), constants.DirPerm)
-			if err != nil {
-				u.config.Logger.Warnf("Failure creating extra dir %s in rootfs at %s", d, upgradeImg.MountPoint)
-			}
-		}
-	}
+	createExtraDirsInRootfs(u.config, u.spec.ExtraDirsRootfs, upgradeImg.MountPoint)
 
 	// Selinux relabel
 	// Doesn't make sense to relabel a readonly filesystem

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -181,6 +181,17 @@ func (u *UpgradeAction) Run() (err error) {
 	}
 	cleanup.Push(func() error { return e.UnmountImage(&upgradeImg) })
 
+	// Create extra dirs in rootfs as afterwards this will be impossible due to RO system
+	for _, d := range u.spec.ExtraDirsRootfs {
+		if exists, _ := fsutils.Exists(u.config.Fs, filepath.Join(upgradeImg.MountPoint, d)); !exists {
+			u.config.Logger.Debugf("Creating extra dir %s under %s", d, upgradeImg.MountPoint)
+			err = u.config.Fs.Mkdir(filepath.Join(upgradeImg.MountPoint, d), constants.DirPerm)
+			if err != nil {
+				u.config.Logger.Warnf("Failure creating extra dir %s in rootfs at %s", d, upgradeImg.MountPoint)
+			}
+		}
+	}
+
 	// Selinux relabel
 	// Doesn't make sense to relabel a readonly filesystem
 	if upgradeImg.FS != constants.SquashFs {

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -56,6 +56,7 @@ type InstallSpec struct {
 	Tty             string              `yaml:"tty,omitempty" mapstructure:"tty"`
 	Reboot          bool                `yaml:"reboot,omitempty" mapstructure:"reboot"`
 	PowerOff        bool                `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
+	ExtraDirsRootfs []string            `yaml:"extra-dirs-rootfs,omitempty" mapstructure:"extra-dirs-rootfs"`
 	Active          Image               `yaml:"system,omitempty" mapstructure:"system"`
 	Recovery        Image               `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
 	Passive         Image
@@ -105,20 +106,20 @@ func (i *InstallSpec) ShouldShutdown() bool { return i.PowerOff }
 
 // ResetSpec struct represents all the reset action details
 type ResetSpec struct {
-	FormatPersistent bool `yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`
-	FormatOEM        bool `yaml:"reset-oem,omitempty" mapstructure:"reset-oem"`
-	Reboot           bool `yaml:"reboot,omitempty" mapstructure:"reboot"`
-	PowerOff         bool `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
-
-	GrubDefEntry string `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
-	Tty          string `yaml:"tty,omitempty" mapstructure:"tty"`
-	Active       Image  `yaml:"system,omitempty" mapstructure:"system"`
-	Passive      Image
-	Partitions   ElementalPartitions
-	Target       string
-	Efi          bool
-	GrubConf     string
-	State        *InstallState
+	FormatPersistent bool     `yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`
+	FormatOEM        bool     `yaml:"reset-oem,omitempty" mapstructure:"reset-oem"`
+	Reboot           bool     `yaml:"reboot,omitempty" mapstructure:"reboot"`
+	PowerOff         bool     `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
+	GrubDefEntry     string   `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
+	Tty              string   `yaml:"tty,omitempty" mapstructure:"tty"`
+	ExtraDirsRootfs  []string `yaml:"extra-dirs-rootfs,omitempty" mapstructure:"extra-dirs-rootfs"`
+	Active           Image    `yaml:"system,omitempty" mapstructure:"system"`
+	Passive          Image
+	Partitions       ElementalPartitions
+	Target           string
+	Efi              bool
+	GrubConf         string
+	State            *InstallState
 }
 
 // Sanitize checks the consistency of the struct, returns error
@@ -137,12 +138,13 @@ func (r *ResetSpec) ShouldReboot() bool   { return r.Reboot }
 func (r *ResetSpec) ShouldShutdown() bool { return r.PowerOff }
 
 type UpgradeSpec struct {
-	RecoveryUpgrade bool   `yaml:"recovery,omitempty" mapstructure:"recovery"`
-	Active          Image  `yaml:"system,omitempty" mapstructure:"system"`
-	Recovery        Image  `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
-	GrubDefEntry    string `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
-	Reboot          bool   `yaml:"reboot,omitempty" mapstructure:"reboot"`
-	PowerOff        bool   `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
+	RecoveryUpgrade bool     `yaml:"recovery,omitempty" mapstructure:"recovery"`
+	Active          Image    `yaml:"system,omitempty" mapstructure:"system"`
+	Recovery        Image    `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
+	GrubDefEntry    string   `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
+	Reboot          bool     `yaml:"reboot,omitempty" mapstructure:"reboot"`
+	PowerOff        bool     `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
+	ExtraDirsRootfs []string `yaml:"extra-dirs-rootfs,omitempty" mapstructure:"extra-dirs-rootfs"`
 	Passive         Image
 	Partitions      ElementalPartitions
 	State           *InstallState


### PR DESCRIPTION
Currently we have an issue that during install,reset,upgrade the rootfs is not able to be managed properly to create extra dirs.

This can be an issue for apps that write to non standard paths and once installed you have to rely in either building your custom image with those dirs or playing with the cc stages to create the dirs.

This new facility allows an user to configure paths to be created during install, upgrade and reset as we have full access to the RW rootfs.