### PR TITLE
Drop override of message options after install

### DIFF
--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -62,7 +62,7 @@ func ManualInstall(c, device string, reboot, poweroff, strictValidations bool) e
 		return err
 	}
 
-	cc, err := config.Scan(collector.Directories(source), collector.MergeBootLine, collector.StrictValidation(strictValidations))
+	cc, err := config.Scan(collector.Directories(source), collector.MergeBootLine, collector.StrictValidation(strictValidations), collector.NoLogs)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,6 @@ func Install(dir ...string) error {
 		}
 
 		if cc.Install.Reboot == false && cc.Install.Poweroff == false {
-			pterm.DefaultInteractiveContinue.Options = []string{}
 			pterm.DefaultInteractiveContinue.Show("Installation completed, press enter to go back to the shell.")
 			svc, err := machine.Getty(1)
 			if err == nil {


### PR DESCRIPTION
This was causing a panic at the end.

also sets the nologs when reading the config in install as that was mistakenly dropped