### PR TITLE
Auto calculate image size on actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jaypipes/ghw v0.12.0
 	github.com/joho/godotenv v1.5.1
-	github.com/kairos-io/kairos-sdk v0.0.11
+	github.com/kairos-io/kairos-sdk v0.0.12
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mudler/go-nodepair v0.0.0-20221223092639-ba399a66fdfb

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,8 @@ github.com/kairos-io/kairos-sdk v0.0.10 h1:TUgrGSGP6Z1CPfA4gjmbb+cCaJg1OR18c+LD+
 github.com/kairos-io/kairos-sdk v0.0.10/go.mod h1:AK9poWisuhnzri04diXnTG8L7EkOSUArSeeDn2LYFU0=
 github.com/kairos-io/kairos-sdk v0.0.11 h1:+EWuO4gWMzBa81s8gbF1L7wOvEjbph1z8UkfUrMyvxc=
 github.com/kairos-io/kairos-sdk v0.0.11/go.mod h1:AK9poWisuhnzri04diXnTG8L7EkOSUArSeeDn2LYFU0=
+github.com/kairos-io/kairos-sdk v0.0.12 h1:+uibTjjsAh8klupXHWpWse2AKww6p8ROu8Ii28t3k48=
+github.com/kairos-io/kairos-sdk v0.0.12/go.mod h1:AK9poWisuhnzri04diXnTG8L7EkOSUArSeeDn2LYFU0=
 github.com/kbinani/screenshot v0.0.0-20210720154843-7d3a670d8329 h1:qq2nCpSrXrmvDGRxW0ruW9BVEV1CN2a9YDOExdt+U0o=
 github.com/kbinani/screenshot v0.0.0-20210720154843-7d3a670d8329/go.mod h1:2VPVQDR4wO7KXHwP+DAypEy67rXf+okUx2zjgpCxZw4=
 github.com/kendru/darwin/go/depgraph v0.0.0-20221105232959-877d6a81060c h1:eKb4PqwAMhlqwXw0W3atpKaYaPGlXE/Fwh+xpCEYaPk=

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -264,8 +264,8 @@ func NewUpgradeSpec(cfg *Config) (*v1.UpgradeSpec, error) {
 		cfg.Logger.Warnf("Failed to infer size for images: %s", err.Error())
 	} else {
 		cfg.Logger.Infof("Setting image size to %dMb", size)
+		// On upgrade only the active or recovery will be upgraded, so we dont need to override passive
 		spec.Active.Size = uint(size)
-		spec.Passive.Size = uint(size)
 		spec.Recovery.Size = uint(size)
 	}
 

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -109,7 +109,7 @@ func NewInstallSpec(cfg *Config) *v1.InstallSpec {
 	}
 
 	// Calculate the partitions afterwards so they use the image sizes for the final partition sizes
-	spec.Partitions = NewInstallElementalPartitions()
+	spec.Partitions = NewInstallElementalPartitions(spec)
 
 	return spec
 }

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -252,7 +252,7 @@ func (e Elemental) UnmountImage(img *v1.Image) error {
 
 // CreateFileSystemImage creates the image file for config.target
 func (e Elemental) CreateFileSystemImage(img *v1.Image) error {
-	e.config.Logger.Infof("Creating file system image %s", img.File)
+	e.config.Logger.Infof("Creating file system image %s with size %dMb", img.File, img.Size)
 	err := fsutils.MkdirAll(e.config.Fs, filepath.Dir(img.File), cnst.DirPerm)
 	if err != nil {
 		return err

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -387,13 +387,13 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 						"mkpart", "oem", "ext4", "133120", "264191",
 					}, {"mkfs.ext4", "-L", "COS_OEM", "/some/device2"}, {
 						"parted", "--script", "--machine", "--", "/some/device", "unit", "s",
-						"mkpart", "recovery", "ext4", "264192", "6760447",
+						"mkpart", "recovery", "ext4", "264192", "468991",
 					}, {"mkfs.ext4", "-L", "COS_RECOVERY", "/some/device3"}, {
 						"parted", "--script", "--machine", "--", "/some/device", "unit", "s",
-						"mkpart", "state", "ext4", "6760448", "19548159",
+						"mkpart", "state", "ext4", "468992", "673791",
 					}, {"mkfs.ext4", "-L", "COS_STATE", "/some/device4"}, {
 						"parted", "--script", "--machine", "--", "/some/device", "unit", "s",
-						"mkpart", "persistent", "ext4", "19548160", "100%",
+						"mkpart", "persistent", "ext4", "673792", "100%",
 					}, {"mkfs.ext4", "-L", "COS_PERSISTENT", "/some/device5"},
 				}
 

--- a/pkg/types/v1/image.go
+++ b/pkg/types/v1/image.go
@@ -22,6 +22,7 @@ import (
 
 type ImageExtractor interface {
 	ExtractImage(imageRef, destination, platformRef string) error
+	GetOCIImageSize(imageRef, platformRef string) (int64, error)
 }
 
 type OCIImageExtractor struct{}
@@ -30,4 +31,8 @@ var _ ImageExtractor = OCIImageExtractor{}
 
 func (e OCIImageExtractor) ExtractImage(imageRef, destination, platformRef string) error {
 	return utils.ExtractOCIImage(imageRef, destination, platformRef)
+}
+
+func (e OCIImageExtractor) GetOCIImageSize(imageRef, platformRef string) (int64, error) {
+	return utils.GetOCIImageSize(imageRef, platformRef)
 }

--- a/pkg/utils/fs/fs.go
+++ b/pkg/utils/fs/fs.go
@@ -20,6 +20,7 @@ limitations under the License.
 package fsutils
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -198,7 +199,7 @@ func WalkDirFs(fs v1.FS, root string, fn fs.WalkDirFunc) error {
 	} else {
 		err = walkDir(fs, root, &statDirEntry{info}, fn)
 	}
-	if err == filepath.SkipDir {
+	if errors.Is(err, filepath.SkipDir) {
 		return nil
 	}
 	return err
@@ -225,7 +226,7 @@ func walkDir(fs v1.FS, path string, d fs.DirEntry, walkDirFn fs.WalkDirFunc) err
 	for _, d1 := range dirs {
 		path1 := filepath.Join(path, d1.Name())
 		if err := walkDir(fs, path1, d1, walkDirFn); err != nil {
-			if err == filepath.SkipDir {
+			if errors.Is(err, filepath.SkipDir) {
 				break
 			}
 			return err

--- a/tests/mocks/extractor_mock.go
+++ b/tests/mocks/extractor_mock.go
@@ -23,6 +23,10 @@ type FakeImageExtractor struct {
 	SideEffect func(imageRef, destination, platformRef string) error
 }
 
+func (f FakeImageExtractor) GetOCIImageSize(imageRef, platformRef string) (int64, error) {
+	return 0, nil
+}
+
 var _ v1.ImageExtractor = FakeImageExtractor{}
 
 func NewFakeImageExtractor(logger v1.Logger) *FakeImageExtractor {


### PR DESCRIPTION
Isntead of using the default static values, during the spec creation we can try to infer the actual size of image, dir or OCI image directly and fall back to the defaults if we are not able to do so.

This is compatible with users overriding the image sizes via cloud-config as its done much earlier, while creating the initial spec, even before loading the values from cloud config into the spec.

This requires https://github.com/kairos-io/kairos-sdk/pull/39 + a new sdk version