### PR TITLE
Add recovery upgrade flag to upgrade command + msg

### DIFF
--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -50,7 +50,7 @@ func ListReleases(includePrereleases bool) semver.Collection {
 }
 
 func Upgrade(
-	version, source string, force, strictValidations bool, dirs []string, preReleases bool) error {
+	version, source string, force, strictValidations bool, dirs []string, preReleases, upgradeRecovery bool) error {
 	bus.Manager.Initialize()
 
 	if version == "" && source == "" {
@@ -110,6 +110,9 @@ func Upgrade(
 		return err
 	}
 	upgradeSpec.Active.Source = imgSource
+
+	// Set the recovery upgrade flag to upgrade recovery or active
+	upgradeSpec.RecoveryUpgrade = upgradeRecovery
 
 	// Sanitize
 	err = upgradeSpec.Sanitize()

--- a/main.go
+++ b/main.go
@@ -69,9 +69,10 @@ var cmds = []*cli.Command{
 				Usage: "Source for upgrade. Composed of `type:address`. Accepts `file:`,`dir:` or `oci:` for the type of source.\nFor example `file:/var/share/myimage.tar`, `dir:/tmp/extracted` or `oci:repo/image:tag`",
 			},
 			&cli.BoolFlag{Name: "pre", Usage: "Include pre-releases (rc, beta, alpha)"},
+			&cli.BoolFlag{Name: "recovery", Usage: "Upgrade recovery"},
 		},
 		Description: `
-Manually upgrade a kairos node.
+Manually upgrade a kairos node Active image. Does not upgrade passive or recovery images.
 
 By default takes no arguments, defaulting to latest available release, to specify a version, pass it as argument:
 
@@ -137,11 +138,10 @@ See https://kairos.io/docs/upgrade/manual/ for documentation.
 			return agent.Upgrade(
 				v, source, c.Bool("force"),
 				c.Bool("strict-validation"), configScanDir,
-				c.Bool("pre"),
+				c.Bool("pre"), c.Bool("recovery"),
 			)
 		},
 	},
-
 	{
 		Name:      "notify",
 		Usage:     "notify <event> <config dir>...",

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -274,6 +274,10 @@ func (u *UpgradeAction) Run() (err error) {
 	}
 
 	u.Info("Upgrade completed")
+	if !u.spec.RecoveryUpgrade {
+		u.config.Logger.Warn("Remember that recovery is upgraded separately by passing the --recovery flag to the upgrade command!\n" +
+			"See more info about this on https://kairos.io/docs/upgrade/")
+	}
 
 	// Do not reboot/poweroff on cleanup errors
 	if cleanErr := cleanup.Cleanup(err); cleanErr != nil {


### PR DESCRIPTION
Adds the --recovery flag to upgrade command to be able to upgrade the recovery. Also adds a message at the end of the upgrade to remind the user that the recovery also needs to be upgraded + docs link.

Fixes #https://github.com/kairos-io/kairos/issues/1678