### PR TITLE
Fix goreleaser artifact names

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,13 +17,7 @@ source:
 archives:
   # Default template uses underscores instead of -
   - name_template: >-
-      {{ .ProjectName }}-
-      {{ .Tag }}-
-      {{- title .Os }}-
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+      {{ .ProjectName }}-{{ .Tag }}-{{- title .Os }}-{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}
 checksum:
   name_template: '{{ .ProjectName }}-{{ .Tag }}-checksums.txt'
 snapshot:


### PR DESCRIPTION
Otherwise the archive files have weird punctuation:` kairos-agent-.v2.2.3-Linux-x86_64.tar.gz`