### PR TITLE
Fix manual-install reboot/poweroff flags

### DIFF
--- a/internal/agent/hooks/lifecycle.go
+++ b/internal/agent/hooks/lifecycle.go
@@ -10,12 +10,12 @@ import (
 type Lifecycle struct{}
 
 func (s Lifecycle) Run(c config.Config, spec v1.Spec) error {
-	if spec.ShouldReboot() {
+	if spec.ShouldReboot() || c.Install.Reboot {
 		time.Sleep(5)
 		utils.Reboot()
 	}
 
-	if spec.ShouldShutdown() {
+	if spec.ShouldShutdown() || c.Install.Poweroff {
 		time.Sleep(5)
 		utils.PowerOFF()
 	}


### PR DESCRIPTION
We were only checking if the spec has the reboot/poweroff enabled but on manual-install we set the values via flags into the Config.Install struct so we need to check that as well

Fixes: https://github.com/kairos-io/kairos/issues/1739