### PR TITLE
Fix recovery image calculation

### DIFF
--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -275,19 +275,18 @@ func NewUpgradeSpec(cfg *Config) (*v1.UpgradeSpec, error) {
 			} else {
 				spec.Active.Source = imgSource
 			}
-		}
-	}
-
-	size, err := GetSourceSize(cfg, spec.Active.Source)
-	if err != nil {
-		cfg.Logger.Warnf("Failed to infer size for images: %s", err.Error())
-	} else {
-		cfg.Logger.Infof("Setting image size to %dMb", size)
-		// On upgrade only the active or recovery will be upgraded, so we dont need to override passive
-		if spec.RecoveryUpgrade {
-			spec.Recovery.Size = uint(size)
-		} else {
-			spec.Active.Size = uint(size)
+			size, err := GetSourceSize(cfg, imgSource)
+			if err != nil {
+				cfg.Logger.Warnf("Failed to infer size for images: %s", err.Error())
+			} else {
+				cfg.Logger.Infof("Setting image size to %dMb", size)
+				// On upgrade only the active or recovery will be upgraded, so we dont need to override passive
+				if recoveryUpgrade {
+					spec.Recovery.Size = uint(size)
+				} else {
+					spec.Active.Size = uint(size)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
We were basica the calculation on the size of the Active.Image but on recovery, the calculation should be done of the Recovery.Image.

That resulted in a value of 0 for the size AND no error.

Instead move the calculation above when we have access the the sourceImage directly and we can calculate it in one go.