### PR TITLE
Track active/passive boot for upgrade workflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jaypipes/ghw v0.12.0
 	github.com/joho/godotenv v1.5.1
-	github.com/kairos-io/kairos-sdk v0.0.13
+	github.com/kairos-io/kairos-sdk v0.0.14
 	github.com/labstack/echo/v4 v4.11.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mudler/go-nodepair v0.0.0-20221223092639-ba399a66fdfb

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kairos-io/kairos-sdk v0.0.13 h1:YI+ETmlk86+mHTQYBNPmVTiO2Ux63HmkRzxhAJRr9JI=
 github.com/kairos-io/kairos-sdk v0.0.13/go.mod h1:+fhVoCEA2hD7OFTmhDmy4pP3uC9q84OYhDa7irkEVWQ=
+github.com/kairos-io/kairos-sdk v0.0.14 h1:yVKaay70cjmAUY6m4uLoV9UguBv3Dx3JxAh2faRlUZo=
+github.com/kairos-io/kairos-sdk v0.0.14/go.mod h1:+fhVoCEA2hD7OFTmhDmy4pP3uC9q84OYhDa7irkEVWQ=
 github.com/kbinani/screenshot v0.0.0-20210720154843-7d3a670d8329 h1:qq2nCpSrXrmvDGRxW0ruW9BVEV1CN2a9YDOExdt+U0o=
 github.com/kbinani/screenshot v0.0.0-20210720154843-7d3a670d8329/go.mod h1:2VPVQDR4wO7KXHwP+DAypEy67rXf+okUx2zjgpCxZw4=
 github.com/kendru/darwin/go/depgraph v0.0.0-20221105232959-877d6a81060c h1:eKb4PqwAMhlqwXw0W3atpKaYaPGlXE/Fwh+xpCEYaPk=

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -384,6 +384,10 @@ var _ = Describe("Runtime Actions", func() {
 						_ = fs.WriteFile(activeImg, source, constants.FilePerm)
 						_ = fs.RemoveAll(spec.Active.File)
 					}
+					if command == "mv" && args[0] == "-f" && args[1] == activeImg && args[2] == passiveImg {
+						// If this command was called then its a complete failure as it tried to copy active into passive
+						StopTrying("Passive was overwritten").Now()
+					}
 					return []byte{}, nil
 				}
 				config.Runner = runner

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -149,6 +149,13 @@ var _ = Describe("Runtime Actions", func() {
 				err = fsutils.MkdirAll(config.Fs, filepath.Join(spec.Active.MountPoint, "etc"), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
 
+				err = fsutils.MkdirAll(config.Fs, "/proc", constants.DirPerm)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Write proc/cmdline so we can detect what we booted from
+				err = fs.WriteFile("/proc/cmdline", []byte(constants.ActiveLabel), constants.FilePerm)
+				Expect(err).ShouldNot(HaveOccurred())
+
 				err = fs.WriteFile(
 					filepath.Join(spec.Active.MountPoint, "etc", "os-release"),
 					[]byte("GRUB_ENTRY_NAME=TESTOS"),
@@ -161,9 +168,6 @@ var _ = Describe("Runtime Actions", func() {
 				spec.Recovery.Size = 10
 
 				runner.SideEffect = func(command string, args ...string) ([]byte, error) {
-					if command == "cat" && args[0] == "/proc/cmdline" {
-						return []byte(constants.ActiveLabel), nil
-					}
 					if command == "mv" && args[0] == "-f" && args[1] == activeImg && args[2] == passiveImg {
 						// we doing backup, do the "move"
 						source, _ := fs.ReadFile(activeImg)
@@ -359,6 +363,13 @@ var _ = Describe("Runtime Actions", func() {
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 
+				err = fsutils.MkdirAll(config.Fs, "/proc", constants.DirPerm)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Write proc/cmdline so we can detect what we booted from
+				err = fs.WriteFile("/proc/cmdline", []byte(constants.PassiveLabel), constants.FilePerm)
+				Expect(err).ShouldNot(HaveOccurred())
+
 				spec.Active.Size = 10
 				spec.Passive.Size = 10
 				spec.Recovery.Size = 10
@@ -435,6 +446,13 @@ var _ = Describe("Runtime Actions", func() {
 					spec.Recovery.Size = 10
 
 					spec.RecoveryUpgrade = true
+
+					err = fsutils.MkdirAll(config.Fs, "/proc", constants.DirPerm)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// Write proc/cmdline so we can detect what we booted from
+					err = fs.WriteFile("/proc/cmdline", []byte(constants.RecoveryLabel), constants.FilePerm)
+					Expect(err).ShouldNot(HaveOccurred())
 
 					runner.SideEffect = func(command string, args ...string) ([]byte, error) {
 						if command == "cat" && args[0] == "/proc/cmdline" {
@@ -521,6 +539,13 @@ var _ = Describe("Runtime Actions", func() {
 					spec.Recovery.Size = 10
 
 					spec.RecoveryUpgrade = true
+
+					err = fsutils.MkdirAll(config.Fs, "/proc", constants.DirPerm)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// Write proc/cmdline so we can detect what we booted from
+					err = fs.WriteFile("/proc/cmdline", []byte(constants.RecoveryLabel), constants.FilePerm)
+					Expect(err).ShouldNot(HaveOccurred())
 
 					runner.SideEffect = func(command string, args ...string) ([]byte, error) {
 						if command == "cat" && args[0] == "/proc/cmdline" {


### PR DESCRIPTION
Track what are we booting from during upgrade in order to not backup active into passive if we are booting from passive.

If we are booting from active or recovery the workflow keeps as it was, backup active into passive, and then move the transition image into active.

Fixes: https://github.com/kairos-io/kairos/issues/1286
Needs: https://github.com/kairos-io/kairos-sdk/pull/46