### PR TITLE
Fix unwanted reboot from install config in upgrade/reset

### DIFF
--- a/internal/agent/hooks/lifecycle.go
+++ b/internal/agent/hooks/lifecycle.go
@@ -9,13 +9,13 @@ import (
 
 type Lifecycle struct{}
 
-func (s Lifecycle) Run(c config.Config, spec v1.Spec) error {
-	if spec.ShouldReboot() || c.Install.Reboot {
+func (s Lifecycle) Run(_ config.Config, spec v1.Spec) error {
+	if spec.ShouldReboot() {
 		time.Sleep(5)
 		utils.Reboot()
 	}
 
-	if spec.ShouldShutdown() || c.Install.Poweroff {
+	if spec.ShouldShutdown() {
 		time.Sleep(5)
 		utils.PowerOFF()
 	}

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -63,28 +63,16 @@ func ManualInstall(c, sourceImgURL, device string, reboot, poweroff, strictValid
 	}
 
 	cliConf := generateInstallConfForCLIArgs(sourceImgURL)
+	cliConfManualArgs := generateInstallConfForManualCLIArgs(device, reboot, poweroff)
 
 	cc, err := config.Scan(collector.Directories(configSource),
-		collector.Readers(strings.NewReader(cliConf)),
+		collector.Readers(strings.NewReader(cliConf), strings.NewReader(cliConfManualArgs)),
 		collector.MergeBootLine,
 		collector.StrictValidation(strictValidations), collector.NoLogs)
 	if err != nil {
 		return err
 	}
-
-	if reboot {
-		// Override from flags!
-		cc.Install.Reboot = true
-	}
-
-	if poweroff {
-		// Override from flags!
-		cc.Install.Poweroff = true
-	}
-	if device != "" {
-		// Override from flags!
-		cc.Install.Device = device
-	}
+	
 	return RunInstall(cc)
 }
 
@@ -349,4 +337,19 @@ func generateInstallConfForCLIArgs(sourceImageURL string) string {
   system:
     uri: %s
 `, sourceImageURL)
+}
+
+// generateInstallConfForManualCLIArgs creates a kairos configuration for flags passed via manual install
+func generateInstallConfForManualCLIArgs(device string, reboot, poweroff bool) string {
+	cfg := fmt.Sprintf(`install:
+  reboot: %t
+  poweroff: %t
+`, reboot, poweroff)
+
+	if device != "" {
+		cfg += fmt.Sprintf(`
+  device: %s
+`, device)
+	}
+	return cfg
 }


### PR DESCRIPTION
provided a call like this:

`elemental-agent --debug manual-install --poweroff --device "dev" --source oci:source /tmp`

it generates the proper collector config to be applied by the spec:

```
  Config: collector.Config{
    "install": collector.Config{
      "device": "dev",
      "poweroff": true,
      "reboot": false,
      "system": collector.Config{
        "uri": "oci:source",
      },
    },
  },

```

So it falls in line with what we been doing in other places, all config merged in a single place.