### PR TITLE
Restore partitions config from cloudconfig

### DIFF
--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		var parts v1.ElementalPartitions
 		BeforeEach(func() {
 			spec := &v1.InstallSpec{}
-			parts = agentConfig.NewInstallElementalPartitions(spec)
+			parts = agentConfig.NewInstallElementalPartitions(logger, spec)
 
 			err := fsutils.MkdirAll(fs, "/some", cnst.DirPerm)
 			Expect(err).ToNot(HaveOccurred())
@@ -149,7 +149,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		var parts v1.ElementalPartitions
 		BeforeEach(func() {
 			spec := &v1.InstallSpec{}
-			parts = agentConfig.NewInstallElementalPartitions(spec)
+			parts = agentConfig.NewInstallElementalPartitions(logger, spec)
 
 			err := fsutils.MkdirAll(fs, "/some", cnst.DirPerm)
 			Expect(err).ToNot(HaveOccurred())
@@ -198,7 +198,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		var parts v1.ElementalPartitions
 		BeforeEach(func() {
 			spec := &v1.InstallSpec{}
-			parts = agentConfig.NewInstallElementalPartitions(spec)
+			parts = agentConfig.NewInstallElementalPartitions(logger, spec)
 
 			err := fsutils.MkdirAll(fs, "/some", cnst.DirPerm)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Now you can override the partition size from config as it used to be.

We also have a safeguard to avoid not having enough space for the image size, logging to mark what size we did end up with and if we had to revert to a safe size.

Fixes: https://github.com/kairos-io/kairos/issues/2151