### PR TITLE
Fix uki upgade path

### DIFF
--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -68,7 +68,7 @@ func Upgrade(
 	source string, force, strictValidations bool, dirs []string, preReleases, upgradeRecovery bool) error {
 	bus.Manager.Initialize()
 
-	if internalutils.UkiBootMode() == internalutils.UkiRemovableMedia {
+	if internalutils.UkiBootMode() == internalutils.UkiHDD {
 		return upgradeUki(source, dirs, strictValidations)
 	} else {
 		return upgrade(source, force, strictValidations, dirs, preReleases, upgradeRecovery)


### PR DESCRIPTION
We were checking the wrong sentinel when upgrading, so we didnt go trougth the uki upgrade path on uki systems but for the normal path, which meant that the normal upgrade spec would be empty due to the differences between systems