### PR TITLE
Remove the proper interactive-install entry by default

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -115,7 +115,7 @@ const (
 )
 
 func UkiDefaultSkipEntries() []string {
-	return []string{"interactive-install", "manual-install"}
+	return []string{"interactive-install", "install-mode-interactive"}
 }
 
 func GetCloudInitPaths() []string {

--- a/pkg/uki/install.go
+++ b/pkg/uki/install.go
@@ -139,6 +139,7 @@ func (i *InstallAction) Run() (err error) {
 
 	// Remove entries
 	// Read all confs
+	i.cfg.Logger.Debugf("Checking for entries to remove")
 	err = fsutils.WalkDirFs(i.cfg.Fs, filepath.Join(i.spec.Partitions.EFI.MountPoint, "loader/entries/"), func(path string, info os.DirEntry, err error) error {
 		i.cfg.Logger.Debugf("Checking file %s", path)
 		if info.IsDir() {


### PR DESCRIPTION
Cover the two different possible keywords