### PR TITLE
Bring uki install up to par with immucore

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -108,7 +108,7 @@ const (
 	Rsync      = "rsync"
 
 	UkiSource         = "/run/install/uki"
-	UkiCdromSource    = "/run/install/cdrom"
+	UkiCdromSource    = "/run/initramfs/live"
 	UkiEfiDir         = "/efi"
 	UkiEfiDiskByLabel = `/dev/disk/by-label/` + EfiLabel
 	UkiMaxEntries     = 3


### PR DESCRIPTION
Immucore now
(https://github.com/kairos-io/immucore/commit/a2874ca3ee5385a0e81a9e9f8c95633939877656) mounts the livecd automatically under the same route that its available on non-uki installs, so its a bit easier on our side as we can assume that the cdrom is mounted in the same path and use that.