### PR TITLE
Adapt uki install to new rootfsbase

### DIFF
--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -504,6 +504,7 @@ type DockerImageMeta struct {
 }
 
 type InstallUkiSpec struct {
+	Active          Image               `yaml:"system,omitempty" mapstructure:"system"`
 	Target          string              `yaml:"device,omitempty" mapstructure:"device"`
 	Reboot          bool                `yaml:"reboot,omitempty" mapstructure:"reboot"`
 	PowerOff        bool                `yaml:"poweroff,omitempty" mapstructure:"poweroff"`


### PR DESCRIPTION
If we know immucore is mounting the livecd under rootfsbase like dracut does, we can do size calculation and prepare the spec much earlier in the process

Part of: https://github.com/kairos-io/kairos/issues/2222