### PR TITLE
Make sure kcrypt hook umounts persistent

### DIFF
--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -27,6 +27,7 @@ func (b BundlePostInstall) Run(c config.Config, _ v1.Spec) error {
 	// - umount the bind dir
 	// Note that the binding of /usr/local/.state/var-lib-extensions.bind to /var/lib/extensions on active/passive its done by inmmucore based on the
 	// 00_rootfs.yaml config which sets the bind and ephemeral paths.
+	c.Logger.Logger.Debug().Msg("Running BundlePostInstall hook")
 
 	machine.Mount("COS_PERSISTENT", "/usr/local") //nolint:errcheck
 	defer func() {
@@ -61,7 +62,7 @@ func (b BundlePostInstall) Run(c config.Config, _ v1.Spec) error {
 	if c.FailOnBundleErrors && err != nil {
 		return err
 	}
-
+	c.Logger.Logger.Debug().Msg("Finish BundlePostInstall hook")
 	return nil
 }
 
@@ -69,10 +70,12 @@ func (b BundlePostInstall) Run(c config.Config, _ v1.Spec) error {
 type BundleFirstBoot struct{}
 
 func (b BundleFirstBoot) Run(c config.Config, _ v1.Spec) error {
+	c.Logger.Logger.Debug().Msg("Running BundleFirstBoot hook")
 	opts := c.Bundles.Options()
 	err := bundles.RunBundles(opts...)
 	if c.FailOnBundleErrors && err != nil {
 		return err
 	}
+	c.Logger.Logger.Debug().Msg("Finish BundleFirstBoot hook")
 	return nil
 }

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
+	"strings"
 
 	config "github.com/kairos-io/kairos-agent/v2/pkg/config"
 	"github.com/kairos-io/kairos-sdk/system"
@@ -16,7 +17,7 @@ func (b GrubOptions) Run(c config.Config, _ v1.Spec) error {
 	c.Logger.Logger.Debug().Msg("Running GrubOptions hook")
 	c.Logger.Debugf("Setting grub options: %s", c.Install.GrubOptions)
 	err := system.Apply(system.SetGRUBOptions(c.Install.GrubOptions))
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "0 errors occurred") {
 		c.Logger.Logger.Error().Err(err).Msg("Failed to set grub options")
 	}
 	c.Logger.Logger.Debug().Msg("Finish GrubOptions hook")

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -1,7 +1,6 @@
 package hook
 
 import (
-	"fmt"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 
 	config "github.com/kairos-io/kairos-agent/v2/pkg/config"
@@ -14,20 +13,27 @@ func (b GrubOptions) Run(c config.Config, _ v1.Spec) error {
 	if len(c.Install.GrubOptions) == 0 {
 		return nil
 	}
+	c.Logger.Logger.Debug().Msg("Running GrubOptions hook")
 	c.Logger.Debugf("Setting grub options: %s", c.Install.GrubOptions)
 	err := system.Apply(system.SetGRUBOptions(c.Install.GrubOptions))
 	if err != nil {
-		fmt.Println(err)
+		c.Logger.Logger.Error().Err(err).Msg("Failed to set grub options")
 	}
+	c.Logger.Logger.Debug().Msg("Finish GrubOptions hook")
 	return nil
 }
 
 type GrubPostInstallOptions struct{}
 
 func (b GrubPostInstallOptions) Run(c config.Config, _ v1.Spec) error {
+	if len(c.GrubOptions) == 0 {
+		return nil
+	}
+	c.Logger.Logger.Debug().Msg("Running GrubOptions hook")
 	err := system.Apply(system.SetGRUBOptions(c.GrubOptions))
 	if err != nil {
-		fmt.Println(err)
+		c.Logger.Logger.Error().Err(err).Msg("Failed to set grub options")
 	}
+	c.Logger.Logger.Debug().Msg("Running GrubOptions hook")
 	return nil
 }

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -13,6 +13,7 @@ var AfterInstall = []Interface{
 	&GrubOptions{}, // Set custom GRUB options
 	&BundlePostInstall{},
 	&CustomMounts{},
+	&CopyLogs{},
 	&Lifecycle{}, // Handles poweroff/reboot by config options
 }
 

--- a/internal/agent/hooks/kcrypt.go
+++ b/internal/agent/hooks/kcrypt.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
+	"github.com/kairos-io/kairos-agent/v2/pkg/constants"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	"github.com/kairos-io/kairos-sdk/machine"
 	kcrypt "github.com/kairos-io/kcrypt/pkg/lib"
@@ -10,10 +11,14 @@ import (
 type Kcrypt struct{}
 
 func (k Kcrypt) Run(c config.Config, _ v1.Spec) error {
-
 	if len(c.Install.Encrypt) == 0 {
 		return nil
 	}
+	c.Logger.Logger.Info().Msg("Running encrypt hook")
+
+	// We need to unmount the persistent partition to encrypt it
+	// we dont know the state here so we better try
+	_ = machine.Umount(constants.PersistentLabel) //nolint:errcheck
 
 	// Config passed during install ends up here, so we need to read it
 	_ = machine.Mount("COS_OEM", "/oem")
@@ -30,6 +35,6 @@ func (k Kcrypt) Run(c config.Config, _ v1.Spec) error {
 			}
 		}
 	}
-
+	c.Logger.Logger.Info().Msg("Finished encrypt hook")
 	return nil
 }

--- a/internal/agent/hooks/kcrypt.go
+++ b/internal/agent/hooks/kcrypt.go
@@ -6,6 +6,7 @@ import (
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	"github.com/kairos-io/kairos-sdk/machine"
 	kcrypt "github.com/kairos-io/kcrypt/pkg/lib"
+	"path/filepath"
 )
 
 type Kcrypt struct{}
@@ -18,7 +19,11 @@ func (k Kcrypt) Run(c config.Config, _ v1.Spec) error {
 
 	// We need to unmount the persistent partition to encrypt it
 	// we dont know the state here so we better try
-	_ = machine.Umount(constants.PersistentLabel) //nolint:errcheck
+	err := machine.Umount(filepath.Join("/dev/disk/by-label", constants.PersistentLabel)) //nolint:errcheck
+	if err != nil {
+		c.Logger.Errorf("could not unmount persistent partition: %s", err)
+		return err
+	}
 
 	// Config passed during install ends up here, so we need to read it
 	_ = machine.Mount("COS_OEM", "/oem")

--- a/internal/agent/hooks/kcrypt_uki.go
+++ b/internal/agent/hooks/kcrypt_uki.go
@@ -55,6 +55,8 @@ func (k KcryptUKI) Run(c config.Config, _ v1.Spec) error {
 		return nil
 	}
 
+	c.Logger.Logger.Debug().Msg("Running KcryptUKI hook")
+
 	// We always encrypt OEM and PERSISTENT under UKI
 	// If mounted, unmount it
 	_ = machine.Umount(constants.OEMDir)        //nolint:errcheck
@@ -177,5 +179,6 @@ func (k KcryptUKI) Run(c config.Config, _ v1.Spec) error {
 	}
 	syscall.Sync()
 	c.Logger.Debug("Logs copied to persistent partition")
+	c.Logger.Logger.Debug().Msg("Finish KcryptUKI hook")
 	return nil
 }

--- a/internal/agent/hooks/lifecycle.go
+++ b/internal/agent/hooks/lifecycle.go
@@ -9,7 +9,8 @@ import (
 
 type Lifecycle struct{}
 
-func (s Lifecycle) Run(_ config.Config, spec v1.Spec) error {
+func (s Lifecycle) Run(c config.Config, spec v1.Spec) error {
+	c.Logger.Logger.Debug().Msg("Running Lifecycle hook")
 	if spec.ShouldReboot() {
 		time.Sleep(5)
 		utils.Reboot()
@@ -19,5 +20,6 @@ func (s Lifecycle) Run(_ config.Config, spec v1.Spec) error {
 		time.Sleep(5)
 		utils.PowerOFF()
 	}
+	c.Logger.Logger.Debug().Msg("Finish Lifecycle hook")
 	return nil
 }

--- a/internal/agent/hooks/logs.go
+++ b/internal/agent/hooks/logs.go
@@ -1,13 +1,17 @@
 package hook
 
 import (
+	"fmt"
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
 	"github.com/kairos-io/kairos-agent/v2/pkg/constants"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	internalutils "github.com/kairos-io/kairos-agent/v2/pkg/utils"
 	fsutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
 	"github.com/kairos-io/kairos-sdk/machine"
+	"github.com/kairos-io/kairos-sdk/utils"
+	kcrypt "github.com/kairos-io/kcrypt/pkg/lib"
 	"path/filepath"
+	"strings"
 	"syscall"
 )
 
@@ -20,6 +24,27 @@ func (k CopyLogs) Run(c config.Config, _ v1.Spec) error {
 	c.Logger.Logger.Debug().Msg("Running CopyLogs hook")
 	c.Logger.Debugf("Copying logs to persistent partition")
 	_ = machine.Umount(constants.PersistentDir)
+
+	// Path if we have encrypted persistent
+	if len(c.Install.Encrypt) != 0 {
+		err := kcrypt.UnlockAll(false)
+		if err != nil {
+			return err
+		}
+		// Close the unencrypted persistent partition at the end!
+		defer func() {
+			for _, p := range []string{constants.PersistentLabel} {
+				c.Logger.Debugf("Closing unencrypted /dev/disk/by-label/%s", p)
+				out, err := utils.SH(fmt.Sprintf("cryptsetup close /dev/disk/by-label/%s", p))
+				// There is a known error with cryptsetup that it can't close the device because of a semaphore
+				// doesnt seem to affect anything as the device is closed as expected so we ignore it if it matches the
+				// output of the error
+				if err != nil && !strings.Contains(out, "incorrect semaphore state") {
+					c.Logger.Errorf("could not close /dev/disk/by-label/%s: %s", p, out)
+				}
+			}
+		}()
+	}
 
 	err := machine.Mount(constants.PersistentLabel, constants.PersistentDir)
 	if err != nil {

--- a/internal/agent/hooks/logs.go
+++ b/internal/agent/hooks/logs.go
@@ -17,6 +17,7 @@ import (
 type CopyLogs struct{}
 
 func (k CopyLogs) Run(c config.Config, _ v1.Spec) error {
+	c.Logger.Logger.Debug().Msg("Running CopyLogs hook")
 	c.Logger.Debugf("Copying logs to persistent partition")
 	_ = machine.Umount(constants.PersistentDir)
 
@@ -47,5 +48,6 @@ func (k CopyLogs) Run(c config.Config, _ v1.Spec) error {
 	}
 	syscall.Sync()
 	c.Logger.Debugf("Logs copied to persistent partition")
+	c.Logger.Logger.Debug().Msg("Finish CopyLogs hook")
 	return nil
 }

--- a/internal/agent/hooks/mounts.go
+++ b/internal/agent/hooks/mounts.go
@@ -36,6 +36,7 @@ func (cm CustomMounts) Run(c config.Config, _ v1.Spec) error {
 	if len(c.Install.BindMounts) == 0 && len(c.Install.EphemeralMounts) == 0 {
 		return nil
 	}
+	c.Logger.Logger.Debug().Msg("Running CustomMounts hook")
 
 	machine.Mount("COS_OEM", "/oem") //nolint:errcheck
 	defer func() {
@@ -56,5 +57,6 @@ func (cm CustomMounts) Run(c config.Config, _ v1.Spec) error {
 	}}
 
 	saveCloudConfig("user_custom_mounts", config) //nolint:errcheck
+	c.Logger.Logger.Debug().Msg("Finish CustomMounts hook")
 	return nil
 }


### PR DESCRIPTION
We cant know its status so we better make sure its unmounted.

Also adds some logging around the hooks to see what they run.

Also adds back the CopyLogs hook that was lost in a rebase probably.