### PR TITLE
Use existing role names for bootentry command on UKI

### DIFF
--- a/pkg/action/bootentries.go
+++ b/pkg/action/bootentries.go
@@ -111,7 +111,6 @@ func selectBootEntrySystemd(cfg *config.Config, entry string) error {
 		cfg.Logger.Errorf("could not read loader.conf: %s", err)
 		return err
 	}
-	fmt.Println("###### here ", originalEntries)
 	if !reflect.DeepEqual(originalEntries, entries) {
 		for _, e := range originalEntries {
 			if strings.HasPrefix(e, entry) {


### PR DESCRIPTION
Switch from active.conf, passive.conf and recovery.conf to cos, fallback and recovery respectively

relates to kairos-io/kairos#2325