### PR TITLE
Mount efi partition if not mounted for bootentries

### DIFF
--- a/pkg/action/bootentries.go
+++ b/pkg/action/bootentries.go
@@ -241,7 +241,7 @@ func listBootEntriesSystemd(cfg *config.Config) error {
 		return err
 	}
 	// mount if not mounted
-	if mounted, _ := utils.IsMounted(cfg, efiPartition); !mounted {
+	if mounted, err := utils.IsMounted(cfg, efiPartition); !mounted && err == nil {
 		if efiPartition.MountPoint == "" {
 			efiPartition.MountPoint = cnst.EfiDir
 		}

--- a/pkg/action/bootentries.go
+++ b/pkg/action/bootentries.go
@@ -316,6 +316,7 @@ func listGrubEntries(cfg *config.Config) ([]string, error) {
 	// /run/initramfs/cos-state/grub/grub.cfg
 	// /etc/kairos/branding/grubmenu.cfg
 	// And grep the entries by checking the --id\s([A-z0-9]*)\s{ pattern
+	// TODO: Check how to run this from livecd as it requires mounting state and grub?
 	var entries []string
 	for _, file := range []string{"/etc/cos/grub.cfg", "/run/initramfs/cos-state/grub/grub.cfg", "/etc/kairos/branding/grubmenu.cfg"} {
 		f, err := cfg.Fs.ReadFile(file)

--- a/pkg/uki/install.go
+++ b/pkg/uki/install.go
@@ -2,6 +2,7 @@ package uki
 
 import (
 	"fmt"
+	"github.com/kairos-io/kairos-agent/v2/pkg/action"
 	"os"
 	"path/filepath"
 	"strings"
@@ -158,6 +159,9 @@ func (i *InstallAction) Run() (err error) {
 		i.cfg.Logger.Errorf("removing artifact set with role %s: %s", UnassignedArtifactRole, err.Error())
 		return fmt.Errorf("removing artifact set with role %s: %w", UnassignedArtifactRole, err)
 	}
+
+	// SelectBootEntry sets the default boot entry to the selected entry
+	err = action.SelectBootEntry(i.cfg, "active")
 
 	err = hook.Run(*i.cfg, i.spec, hook.UKIEncryptionHooks...)
 	if err != nil {

--- a/pkg/uki/install.go
+++ b/pkg/uki/install.go
@@ -162,6 +162,9 @@ func (i *InstallAction) Run() (err error) {
 
 	// SelectBootEntry sets the default boot entry to the selected entry
 	err = action.SelectBootEntry(i.cfg, "active")
+	if err != nil {
+		i.cfg.Logger.Warnf("selecting active boot entry: %s", err.Error())
+	}
 
 	err = hook.Run(*i.cfg, i.spec, hook.UKIEncryptionHooks...)
 	if err != nil {


### PR DESCRIPTION
So we can run it on livecd after the install or in other places (reset)

Fixes: https://github.com/kairos-io/kairos/issues/2334