### PR TITLE
After upgrade or recovery, set bootentry to "cos"

### DIFF
--- a/pkg/uki/install.go
+++ b/pkg/uki/install.go
@@ -161,7 +161,7 @@ func (i *InstallAction) Run() (err error) {
 	}
 
 	// SelectBootEntry sets the default boot entry to the selected entry
-	err = action.SelectBootEntry(i.cfg, "active")
+	err = action.SelectBootEntry(i.cfg, "cos")
 	if err != nil {
 		i.cfg.Logger.Warnf("selecting active boot entry: %s", err.Error())
 	}

--- a/pkg/uki/reset.go
+++ b/pkg/uki/reset.go
@@ -81,7 +81,7 @@ func (r *ResetAction) Run() (err error) {
 		return fmt.Errorf("copying recovery to active: %w", err)
 	}
 	// SelectBootEntry sets the default boot entry to the selected entry
-	err = action.SelectBootEntry(r.cfg, "active")
+	err = action.SelectBootEntry(r.cfg, "cos")
 	// Should we fail? Or warn?
 	if err != nil {
 		r.cfg.Logger.Errorf("selecting boot entry : %s", err.Error())

--- a/pkg/uki/upgrade.go
+++ b/pkg/uki/upgrade.go
@@ -90,7 +90,7 @@ func (i *UpgradeAction) Run() (err error) {
 	}
 
 	// SelectBootEntry sets the default boot entry to the selected entry
-	err = action.SelectBootEntry(i.cfg, "active")
+	err = action.SelectBootEntry(i.cfg, "cos")
 	// Should we fail? Or warn?
 	if err != nil {
 		i.cfg.Logger.Errorf("selecting boot entry: %s", err.Error())


### PR DESCRIPTION
Previously we used to call this active but since the bootentry change, this should be cos instead

fixes kairos-io/kairos#2354