### PR TITLE
Add a scanner for config with nulllogger

### DIFF
--- a/main.go
+++ b/main.go
@@ -351,7 +351,7 @@ enabled: true`,
 				Description: "It allows to navigate the YAML config file by searching with 'yq' style keywords as `config get k3s` to retrieve the k3s config block",
 				Aliases:     []string{"g"},
 				Action: func(c *cli.Context) error {
-					config, err := agentConfig.Scan(collector.Directories(constants.GetConfigScanDirs()...), collector.NoLogs, collector.StrictValidation(c.Bool("strict-validation")))
+					config, err := agentConfig.ScanNoLogs(collector.Directories(constants.GetConfigScanDirs()...), collector.NoLogs, collector.StrictValidation(c.Bool("strict-validation")))
 					if err != nil {
 						return err
 					}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -329,10 +329,22 @@ func FilterKeys(d []byte) ([]byte, error) {
 	return out, nil
 }
 
-func Scan(opts ...collector.Option) (c *Config, err error) {
-	// Init new config with some default options
-	result := NewConfig()
+// ScanNoLogs is a wrapper around Scan that sets the logger to null
+func ScanNoLogs(opts ...collector.Option) (c *Config, err error) {
+	log := sdkTypes.NewNullLogger()
+	result := NewConfig(WithLogger(log))
+	return scan(result, opts...)
+}
 
+// Scan is a wrapper around collector.Scan that sets the logger to the default Kairos logger
+func Scan(opts ...collector.Option) (c *Config, err error) {
+	result := NewConfig()
+	return scan(result, opts...)
+}
+
+// scan is the internal function that does the actual scanning of the configs
+func scan(result *Config, opts ...collector.Option) (c *Config, err error) {
+	// Init new config with some default options
 	o := &collector.Options{}
 	if err := o.Apply(opts...); err != nil {
 		return result, err


### PR DESCRIPTION
To create a new config but discards the logs

Fixes: https://github.com/kairos-io/kairos/issues/2342