### PR TITLE
Fix bootentry

### DIFF
--- a/pkg/action/bootentries.go
+++ b/pkg/action/bootentries.go
@@ -203,9 +203,9 @@ func systemdConfToBootName(conf string) (string, error) {
 		return bootName, nil
 	}
 
-	if strings.HasPrefix(conf, "autoreset") {
-		bootName := "autoreset"
-		confName := strings.TrimPrefix(fileName, "autoreset")
+	if strings.HasPrefix(conf, "statereset") {
+		bootName := "statereset"
+		confName := strings.TrimPrefix(fileName, "statereset")
 
 		if confName != "" {
 			bootName = bootName + " " + strings.Trim(confName, "_")
@@ -248,11 +248,11 @@ func bootNameToSystemdConf(name string) (string, error) {
 		return "recovery" + differenciator + ".conf", nil
 	}
 
-	if strings.HasPrefix(name, "autoreset") {
-		if name != "autoreset" {
-			differenciator = "_" + strings.TrimPrefix(name, "autoreset ")
+	if strings.HasPrefix(name, "statereset") {
+		if name != "statereset" {
+			differenciator = "_" + strings.TrimPrefix(name, "statereset ")
 		}
-		return "autoreset" + differenciator + ".conf", nil
+		return "statereset" + differenciator + ".conf", nil
 
 	}
 

--- a/pkg/action/bootentries.go
+++ b/pkg/action/bootentries.go
@@ -83,9 +83,9 @@ func selectBootEntrySystemd(cfg *config.Config, entry string) error {
 
 	}
 	originalEntries := entries
-	// when there are only 3 entries, we can assume they are either cos (which will be replaced eventually), fallback or recovery
-	if len(entries) == 3 {
-		entries = []string{"cos", "fallback", "recovery", "autoreset"}
+	// when there are only 4 entries, we can assume they are either cos (which will be replaced eventually), fallback, recovery or autoreset
+	if len(entries) == len(cnst.UkiDefaultMenuEntries()) {
+		entries = cnst.UkiDefaultMenuEntries()
 	}
 
 	// Check that entry exists in the entries list
@@ -204,7 +204,7 @@ func systemdConfToBootName(conf string) (string, error) {
 	}
 
 	if strings.HasPrefix(conf, "autoreset") {
-		bootName := "auto reset"
+		bootName := "autoreset"
 		confName := strings.TrimPrefix(fileName, "autoreset")
 
 		if confName != "" {

--- a/pkg/action/bootentries_test.go
+++ b/pkg/action/bootentries_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 				Expect(err).ToNot(HaveOccurred())
 				err = fs.WriteFile("/efi/loader/entries/recovery.conf", []byte("title kairos recovery\nefi /EFI/kairos/recovery.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
-				err = fs.WriteFile("/efi/loader/entries/autoreset.conf", []byte("title kairos autoreset\nefi /EFI/kairos/autoreset.efi\n"), os.ModePerm)
+				err = fs.WriteFile("/efi/loader/entries/statereset.conf", []byte("title kairos state reset (auto)\nefi /EFI/kairos/statereset.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
 
 				entries, err := listSystemdEntries(config, &v1.Partition{MountPoint: "/efi"})
@@ -123,7 +123,7 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 				Expect(entries).To(ContainElement("cos"))
 				Expect(entries).To(ContainElement("fallback"))
 				Expect(entries).To(ContainElement("recovery"))
-				Expect(entries).To(ContainElement("autoreset"))
+				Expect(entries).To(ContainElement("statereset"))
 
 			})
 			It("list empty boot entries if there is none", func() {
@@ -146,7 +146,7 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 				Expect(err).ToNot(HaveOccurred())
 				err = fs.WriteFile("/efi/loader/entries/recovery.conf", []byte("title kairos recovery\nefi /EFI/kairos/recovery.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
-				err = fs.WriteFile("/efi/loader/entries/autoreset.conf", []byte("title kairos autoreset\nefi /EFI/kairos/autoreset.efi\n"), os.ModePerm)
+				err = fs.WriteFile("/efi/loader/entries/statereset.conf", []byte("title kairos state reset (auto)\nefi /EFI/kairos/statereset.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
 				err = fs.WriteFile("/efi/loader/loader.conf", []byte(""), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
@@ -193,12 +193,12 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 					syscall.MS_REMOUNT|syscall.MS_RDONLY,
 					"")).To(BeTrue())
 
-				err = SelectBootEntry(config, "autoreset")
+				err = SelectBootEntry(config, "statereset")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to autoreset"))
+				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to statereset"))
 				reader, err = utils.SystemdBootConfReader(fs, "/efi/loader/loader.conf")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(reader["default"]).To(Equal("autoreset.conf"))
+				Expect(reader["default"]).To(Equal("statereset.conf"))
 				// Should have called a remount to make it RW
 				Expect(syscallMock.WasMountCalledWith(
 					"",
@@ -265,7 +265,7 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 				Expect(err).ToNot(HaveOccurred())
 				err = fs.WriteFile("/efi/loader/entries/recovery_install-mode_awesomeos.conf", []byte("title awesomeos recovery\nefi /EFI/kairos/recovery_install-mode_awesomeos.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
-				err = fs.WriteFile("/efi/loader/entries/autoreset_install-mode_awesomeos.conf", []byte("title awesomeos autoreset\nefi /EFI/kairos/autoreset_install-mode_awesomeos.efi\n"), os.ModePerm)
+				err = fs.WriteFile("/efi/loader/entries/statereset_install-mode_awesomeos.conf", []byte("title awesomeos state reset (auto)\nefi /EFI/kairos/statereset_install-mode_awesomeos.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
 				err = fs.WriteFile("/efi/loader/loader.conf", []byte(""), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
@@ -312,12 +312,12 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 					syscall.MS_REMOUNT|syscall.MS_RDONLY,
 					"")).To(BeTrue())
 
-				err = SelectBootEntry(config, "autoreset")
+				err = SelectBootEntry(config, "statereset")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to autoreset"))
+				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to statereset"))
 				reader, err = utils.SystemdBootConfReader(fs, "/efi/loader/loader.conf")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(reader["default"]).To(Equal("autoreset_install-mode_awesomeos.conf"))
+				Expect(reader["default"]).To(Equal("statereset_install-mode_awesomeos.conf"))
 				// Should have called a remount to make it RW
 				Expect(syscallMock.WasMountCalledWith(
 					"",
@@ -390,9 +390,9 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 				Expect(err).ToNot(HaveOccurred())
 				err = fs.WriteFile("/efi/loader/entries/recovery_foobar.conf", []byte("title Kairos recovery\nefi /EFI/kairos/recovery_foobar.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
-				err = fs.WriteFile("/efi/loader/entries/autoreset.conf", []byte("title Kairos autoreset\nefi /EFI/kairos/autoreset.efi\n"), os.ModePerm)
+				err = fs.WriteFile("/efi/loader/entries/statereset.conf", []byte("title Kairos state reset (auto)\nefi /EFI/kairos/statereset.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
-				err = fs.WriteFile("/efi/loader/entries/autoreset_foobar.conf", []byte("title Kairos autoreset\nefi /EFI/kairos/autoreset_foobar.efi\n"), os.ModePerm)
+				err = fs.WriteFile("/efi/loader/entries/statereset_foobar.conf", []byte("title Kairos state reset (auto)\nefi /EFI/kairos/state_reset_foobar.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
 				err = fs.WriteFile("/efi/loader/loader.conf", []byte(""), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
@@ -481,12 +481,12 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 					syscall.MS_REMOUNT|syscall.MS_RDONLY,
 					"")).To(BeTrue())
 
-				err = SelectBootEntry(config, "autoreset")
+				err = SelectBootEntry(config, "statereset")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to autoreset"))
+				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to statereset"))
 				reader, err = utils.SystemdBootConfReader(fs, "/efi/loader/loader.conf")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(reader["default"]).To(Equal("autoreset.conf"))
+				Expect(reader["default"]).To(Equal("statereset.conf"))
 				// Should have called a remount to make it RW
 				Expect(syscallMock.WasMountCalledWith(
 					"",
@@ -502,12 +502,12 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 					syscall.MS_REMOUNT|syscall.MS_RDONLY,
 					"")).To(BeTrue())
 
-				err = SelectBootEntry(config, "autoreset foobar")
+				err = SelectBootEntry(config, "statereset foobar")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to autoreset foobar"))
+				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to statereset foobar"))
 				reader, err = utils.SystemdBootConfReader(fs, "/efi/loader/loader.conf")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(reader["default"]).To(Equal("autoreset_foobar.conf"))
+				Expect(reader["default"]).To(Equal("statereset_foobar.conf"))
 				// Should have called a remount to make it RW
 				Expect(syscallMock.WasMountCalledWith(
 					"",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -83,7 +83,7 @@ const (
 	ActiveImgName           = "active"
 	PassiveImgName          = "passive"
 	RecoveryImgName         = "recovery"
-	AutoResetEntryName      = "autoreset"
+	StateResetImgName       = "statereset"
 	GPT                     = "gpt"
 	UsrLocalPath            = "/usr/local"
 	OEMPath                 = "/oem"
@@ -117,12 +117,13 @@ const (
 	UkiMaxEntries     = 3
 
 	// Boot labeling
-	PassiveBootSuffix  = " (fallback)"
-	RecoveryBootSuffix = " recovery"
+	PassiveBootSuffix    = " (fallback)"
+	RecoveryBootSuffix   = " recovery"
+	StateResetBootSuffix = " state reset (auto)"
 )
 
 func UkiDefaultMenuEntries() []string {
-	return []string{"cos", "fallback", "recovery", "autoreset"}
+	return []string{"cos", "fallback", "recovery", "statereset"}
 }
 
 func UkiDefaultSkipEntries() []string {
@@ -177,8 +178,8 @@ func BaseBootTitle(title string) string {
 		return strings.TrimSuffix(title, RecoveryBootSuffix)
 	} else if strings.HasSuffix(title, PassiveBootSuffix) {
 		return strings.TrimSuffix(title, PassiveBootSuffix)
-	} else if strings.HasSuffix(title, AutoResetEntryName) {
-		return strings.TrimSuffix(title, AutoResetEntryName)
+	} else if strings.HasSuffix(title, StateResetBootSuffix) {
+		return strings.TrimSuffix(title, StateResetBootSuffix)
 	}
 	return title
 }
@@ -191,8 +192,8 @@ func BootTitleForRole(role, title string) (string, error) {
 		return BaseBootTitle(title) + PassiveBootSuffix, nil
 	case RecoveryImgName:
 		return BaseBootTitle(title) + RecoveryBootSuffix, nil
-	case AutoResetEntryName:
-		return BaseBootTitle(title) + " " + AutoResetEntryName, nil
+	case StateResetImgName:
+		return BaseBootTitle(title) + StateResetBootSuffix, nil
 	default:
 		return "", errors.New("invalid role")
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -121,6 +121,10 @@ const (
 	RecoveryBootSuffix = " recovery"
 )
 
+func UkiDefaultMenuEntries() []string {
+	return []string{"cos", "fallback", "recovery", "autoreset"}
+}
+
 func UkiDefaultSkipEntries() []string {
 	return []string{"interactive-install", "install-mode-interactive"}
 }

--- a/pkg/uki/install.go
+++ b/pkg/uki/install.go
@@ -2,10 +2,11 @@ package uki
 
 import (
 	"fmt"
-	"github.com/kairos-io/kairos-agent/v2/pkg/action"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/kairos-io/kairos-agent/v2/pkg/action"
 
 	hook "github.com/kairos-io/kairos-agent/v2/internal/agent/hooks"
 	"github.com/kairos-io/kairos-agent/v2/pkg/config"
@@ -142,7 +143,7 @@ func (i *InstallAction) Run() (err error) {
 		return err
 	}
 
-	for _, role := range []string{"active", "passive", "recovery", "autoreset"} {
+	for _, role := range constants.UkiDefaultMenuEntries() {
 		if err = copyArtifactSetRole(i.cfg.Fs, i.spec.Partitions.EFI.MountPoint, UnassignedArtifactRole, role, i.cfg.Logger); err != nil {
 			i.cfg.Logger.Errorf("installing the new artifact set as %s: %s", role, err.Error())
 			return fmt.Errorf("installing the new artifact set as %s: %w", role, err)


### PR DESCRIPTION
- Added tests for autoreset boot entry
- Fixed the issue with the name of autoreset being "auto reset" on one side and "autoreset" on another
- fixed check now for default as 4 entries
- moved default entries as a constant to avoid this issue in the future

fixes kairos-io/kairos#2408