### PR TITLE
Centralize uki hooks for encryption reasons

### DIFF
--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -33,8 +33,6 @@ var FirstBoot = []Interface{
 
 // AfterUkiInstall sets which Hooks to run after uki runs the install action
 var AfterUkiInstall = []Interface{
-	&BundlePostInstall{},
-	&CustomMounts{},
 	&Lifecycle{},
 }
 


### PR DESCRIPTION
This makes the hooks work without modifications to them, as they already mount/unmount oem/persistent and do it while they are unlocked