### PR TITLE
Force go 1.19 for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.20
+          go-version: '^1.19.10'
       - name: Build WebUI dependencies
         run: cd ./internal/webui/public && npm install
       - name: Run GoReleaser


### PR DESCRIPTION
releases currently break with https://github.com/kairos-io/kairos-agent/actions/runs/9076504210/job/24939339874