### PR TITLE
Ensure only numeric part of systemd version is converted to int

### DIFF
--- a/internal/agent/hooks/kcrypt_uki.go
+++ b/internal/agent/hooks/kcrypt_uki.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -31,6 +32,12 @@ func (k KcryptUKI) Run(c config.Config, spec v1.Spec) error {
 	if systemdVersion == "" {
 		c.Logger.Errorf("could not get systemd version: %s", err)
 		return err
+	}
+	// Extract the numeric portion of the version string using a regular expression
+	re := regexp.MustCompile(`\d+`)
+	matches := re.FindString(systemdVersion)
+	if matches == "" {
+		return fmt.Errorf("could not extract numeric part from systemd version: %s", systemdVersion)
 	}
 	// Change systemdVersion to int value
 	systemdVersionInt, err := strconv.Atoi(systemdVersion)


### PR DESCRIPTION
some distributions might include pre-release or release-candidate versions, e.g. debian:testing currently ships
"systemd 256~rc3 (256~rc3-7)".
This breaks `strconv.Atoi(systemdVersion)` when it receives the tilde character.

This change introduces a regular expression to ensure we only use the numeric part of the systemd version.