### PR TITLE
Skip dirs in copyArtifactSetRole and replace only basename

### DIFF
--- a/pkg/uki/common_test.go
+++ b/pkg/uki/common_test.go
@@ -1,0 +1,64 @@
+package uki
+
+import (
+	"bytes"
+	"os"
+
+	cnst "github.com/kairos-io/kairos-agent/v2/pkg/constants"
+	fsutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
+	sdkTypes "github.com/kairos-io/kairos-sdk/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/twpayne/go-vfs/v4"
+	"github.com/twpayne/go-vfs/v4/vfst"
+)
+
+var _ = Describe("Common functions tests", func() {
+	Describe("copyArtifactSetRole", func() {
+		var fs vfs.FS
+		var err error
+		var memLog *bytes.Buffer
+		var logger sdkTypes.KairosLogger
+
+		BeforeEach(func() {
+			fs, _, err = vfst.NewTestFS(map[string]interface{}{})
+			Expect(err).ToNot(HaveOccurred())
+
+			logger = sdkTypes.NewBufferLogger(memLog)
+			logger.SetLevel("debug")
+
+			Expect(fsutils.MkdirAll(fs, "/active", cnst.DirPerm)).ToNot(HaveOccurred())
+			Expect(fsutils.MkdirAll(fs, "/other", cnst.DirPerm)).ToNot(HaveOccurred())
+
+			f, err := fs.Create("/other/active.efi")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = os.Stat(f.Name())
+			Expect(err).ToNot(HaveOccurred())
+
+			f, err = fs.Create("/other/other.efi")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = os.Stat(f.Name())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("skips directories", func() {
+			err = copyArtifactSetRole(fs, "/", "active", "passive", logger)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("replaces only the base file name", func() {
+			err = copyArtifactSetRole(fs, "/other", "other", "newother", logger)
+			Expect(err).ToNot(HaveOccurred())
+
+			glob, _ := fs.Glob("/other/*")
+			Expect(glob).To(HaveExactElements([]string{
+				"/other/active.efi",
+				"/other/newother.efi",
+				"/other/other.efi",
+			}))
+		})
+	})
+})

--- a/pkg/uki/suite_test.go
+++ b/pkg/uki/suite_test.go
@@ -1,0 +1,13 @@
+package uki_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestActionSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Uki test suite")
+}


### PR DESCRIPTION
otherwise we get the error (on `kairos-agent upgrade` in uki mode):

```
panic: open /efi/EFI/kairos/passive.efi.extra.d: is a directory
```

and we may replace parts of the path that we shouldn't.