### PR TITLE
Do not skip /run when counting the size

### DIFF
--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -826,12 +826,11 @@ func GetSourceSize(config *Config, source *v1.ImageSource) (int64, error) {
 			hostDir = "/host"
 		}
 		err = fsutils.WalkDirFs(config.Fs, source.Value(), func(path string, d fs.DirEntry, err error) error {
-
 			// If its empty we are just not setting it, so probably out of the k8s upgrade path
 			if hostDir != "" && strings.HasPrefix(path, hostDir) {
 				config.Logger.Logger.Debug().Str("path", path).Str("hostDir", hostDir).Msg("Skipping file as it is a host directory")
-			} else if strings.HasPrefix(path, "/proc") || strings.HasPrefix(path, "/dev") || strings.HasPrefix(path, "/run") {
-				config.Logger.Logger.Debug().Str("path", path).Str("hostDir", hostDir).Msg("Skipping dir as it is a system directory (/proc, /dev or /run)")
+			} else if strings.HasPrefix(path, "/proc") || strings.HasPrefix(path, "/dev") {
+				config.Logger.Logger.Debug().Str("path", path).Str("hostDir", hostDir).Msg("Skipping dir as it is a runtime directory (/proc or /dev)")
 			} else {
 				v := getSize(&size, filesVisited, path, d, err)
 				return v


### PR DESCRIPTION
This would affect installing from livecd and while its a runtime dir, it doesnt have the side effects that system runtime dirs like dev or proc have.