### PR TITLE
Expose the Analize method of yip

### DIFF
--- a/main.go
+++ b/main.go
@@ -667,6 +667,11 @@ The validate command expects a configuration file as its only argument. Local fi
 				Name:  "cloud-init-paths",
 				Usage: "Extra paths to add to the run stage",
 			},
+			&cli.BoolFlag{
+				Name:    "analyze",
+				Usage:   "Only print the modules that would run in the order they would run",
+				Aliases: []string{"a"},
+			},
 		},
 		Before: func(c *cli.Context) error {
 			if c.Args().Len() != 1 {
@@ -691,6 +696,9 @@ The validate command expects a configuration file as its only argument. Local fi
 
 			if err != nil {
 				config.Logger.Errorf("Error reading config: %s\n", err)
+			}
+			if c.Bool("analyze") {
+				return utils.RunStageAnalyze(config, stage)
 			}
 			return utils.RunStage(config, stage)
 		},

--- a/pkg/cloudinit/cloudinit.go
+++ b/pkg/cloudinit/cloudinit.go
@@ -81,3 +81,7 @@ func (ci *YipCloudInitRunner) SetModifier(m schema.Modifier) {
 func (ci *YipCloudInitRunner) SetFs(fs vfs.FS) {
 	ci.fs = fs
 }
+
+func (ci *YipCloudInitRunner) Analyze(stage string, args ...string) {
+	ci.exec.Analyze(stage, vfs.OSFS, ci.console, args...)
+}

--- a/pkg/types/v1/cloud-init-runner.go
+++ b/pkg/types/v1/cloud-init-runner.go
@@ -22,5 +22,6 @@ import (
 
 type CloudInitRunner interface {
 	Run(string, ...string) error
+	Analyze(string, ...string)
 	SetModifier(schema.Modifier)
 }

--- a/tests/mocks/cloud-init-runner_mock.go
+++ b/tests/mocks/cloud-init-runner_mock.go
@@ -37,3 +37,5 @@ func (ci *FakeCloudInitRunner) Run(stage string, args ...string) error {
 
 func (ci *FakeCloudInitRunner) SetModifier(modifier schema.Modifier) {
 }
+
+func (ci *FakeCloudInitRunner) Analyze(stage string, args ...string) {}


### PR DESCRIPTION
This only shows for a given stage what steps would be run and in which order

With a given yaml as this


```yaml
name: test stage
stages:
  test.after:
    - name: AFTER
  test.before:
    - name: BEFORE
  test:
    - name: test1
    - name: test2
```

The output is as follows:

```shell
$ go run main.go run-stage -a --cloud-init-paths . test
2024-09-19T12:54:47+02:00 INF Kairos Agent version=v0.0.1
2024-09-19T12:54:47+02:00 INF creating a runtime
2024-09-19T12:54:47+02:00 INF detecting boot state
2024-09-19T12:54:47+02:00 INF Boot Mode boot_mode=unknown
2024-09-19T12:54:47+02:00 INF Boot in uki mode result=false
2024-09-19T12:54:47+02:00 INF Analyze mode, showing DAG
2024-09-19T12:54:47+02:00 INF 1.
2024-09-19T12:54:47+02:00 INF  <init> (background: false) (weak: false)
2024-09-19T12:54:47+02:00 INF 2.
2024-09-19T12:54:47+02:00 INF  <test stage.BEFORE> (background: false) (weak: true)
2024-09-19T12:54:47+02:00 INF 1.
2024-09-19T12:54:47+02:00 INF  <init> (background: false) (weak: false)
2024-09-19T12:54:47+02:00 INF 2.
2024-09-19T12:54:47+02:00 INF  <test stage.test1> (background: false) (weak: true)
2024-09-19T12:54:47+02:00 INF 3.
2024-09-19T12:54:47+02:00 INF  <test stage.test2> (background: false) (weak: true)
2024-09-19T12:54:47+02:00 INF 1.
2024-09-19T12:54:47+02:00 INF  <init> (background: false) (weak: false)
2024-09-19T12:54:47+02:00 INF 2.
2024-09-19T12:54:47+02:00 INF  <test stage.AFTER> (background: false) (weak: true)
```