### PR TITLE
Accept more paths to devices for install

### DIFF
--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -75,27 +75,36 @@ type InstallSpec struct {
 	GrubConf        string
 }
 
+// TODO: Move it to the sdk, make it use a vfs to read the link
+func resolveTarget(target string) (string, error) {
+	// Accept that the target can be a /dev/disk/by-{label,uuid,path,etc..} and resolve it into a /dev/device
+	if strings.HasPrefix(target, "/dev/disk/by-") {
+		// we dont accept partitions as target so check and fail earlier for those that are partuuid or parlabel
+		if strings.Contains(target, "partlabel") || strings.Contains(target, "partuuid") {
+			return "", fmt.Errorf("target contains 'parlabel' or 'partuuid', looks like its a partition instead of a disk: %s", target)
+		}
+		device, err := os.Readlink(target)
+		if err != nil {
+			return "", fmt.Errorf("failed to read device link for %s: %w", target, err)
+		}
+		if !strings.HasPrefix(device, "/dev/") {
+			return "", fmt.Errorf("device %s is not a valid device path", device)
+		}
+		return device, nil
+	}
+	// If we dont resolve and dont fail, just return the original target
+	return target, nil
+}
+
 // Sanitize checks the consistency of the struct, returns error
 // if unsolvable inconsistencies are found
 func (i *InstallSpec) Sanitize() error {
-	// Accept that the target can be a /dev/disk/by-{label,uuid,path,etc..} and resolve it into a /dev/device
-	if strings.HasPrefix(i.Target, "/dev/disk/by-") {
-		// we dont accept partitions as target so check and fail earlier for those that are partuuid or parlabel
-		if strings.Contains(i.Target, "parlabel") || strings.Contains(i.Target, "partuuid") {
-			return fmt.Errorf("target contains 'parlabel' or 'partuuid', looks like its a partition instead of a disk: %s", i.Target)
-		}
-		device, err := os.Readlink(i.Target)
-		if err != nil {
-			return fmt.Errorf("failed to read device link for %s: %w", i.Target, err)
-		}
-		if !strings.HasPrefix(device, "/dev/") {
-			return fmt.Errorf("device %s is not a valid device path", device)
-		}
-		i.Target = device
+	var err error
+	i.Target, err = resolveTarget(i.Target)
+	if err != nil {
+		return err
 	}
-
 	// Check if the target device has mounted partitions
-
 	for _, disk := range ghw.GetDisks(ghw.NewPaths(""), nil) {
 		if fmt.Sprintf("/dev/%s", disk.Name) == i.Target {
 			for _, p := range disk.Partitions {

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -79,7 +79,11 @@ type InstallSpec struct {
 // if unsolvable inconsistencies are found
 func (i *InstallSpec) Sanitize() error {
 	// Accept that the target can be a /dev/disk/by-{label,uuid,path,etc..} and resolve it into a /dev/device
-	if strings.HasPrefix("/dev/disk/by-", i.Target) {
+	if strings.HasPrefix(i.Target, "/dev/disk/by-") {
+		// we dont accept partitions as target so check and fail earlier for those that are partuuid or parlabel
+		if strings.Contains(i.Target, "parlabel") || strings.Contains(i.Target, "partuuid") {
+			return fmt.Errorf("target contains 'parlabel' or 'partuuid', looks like its a partition instead of a disk: %s", i.Target)
+		}
 		device, err := os.Readlink(i.Target)
 		if err != nil {
 			return fmt.Errorf("failed to read device link for %s: %w", i.Target, err)


### PR DESCRIPTION
Accepts any of the paths that udev adds for ease of use and are laying
under /dev/disk/by-X

As those are all softlinks to the actual device, it should be faily easy
to just read the link and use the final target as that should always be
a full device path (/dev/vda for example)

Fixes: https://github.com/kairos-io/kairos/issues/1879

Signed-off-by: Itxaka <itxaka@kairos.io>