### PR TITLE
Fix mkfs using the wrong label for the fs label

### DIFF
--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -110,7 +110,7 @@ func (e *Elemental) PartitionAndFormatDevice(i v1.SharedInstallSpec) error {
 				continue
 			}
 			// we have to match the Fs it was asked with the partition in the system
-			if p.(*gpt.Partition).Name == configPart.FilesystemLabel {
+			if p.(*gpt.Partition).Name == configPart.Name {
 				e.config.Logger.Debugf("Formatting partition: %s", configPart.FilesystemLabel)
 				err = partitioner.FormatDevice(e.config.Runner, fmt.Sprintf("%s%d", i.GetTarget(), index+1), configPart.FS, configPart.FilesystemLabel)
 				if err != nil {

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -398,7 +398,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			// Should be efi type
 			Expect(partition.Type).To(Equal(gpt.EFISystemPartition))
 			// should have boot label
-			Expect(partition.Name).To(Equal(cnst.EfiLabel))
+			Expect(partition.Name).To(Equal(cnst.EfiPartName))
 			// Should have predictable UUID
 			Expect(strings.ToLower(partition.UUID())).To(Equal(strings.ToLower(uuid.NewV5(uuid.NamespaceURL, cnst.EfiLabel).String())))
 			// Check the rest have the proper types
@@ -431,7 +431,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			// Should be BIOS boot type
 			Expect(partition.Type).To(Equal(gpt.BIOSBoot))
 			// should have boot label
-			Expect(partition.Name).To(Equal(cnst.EfiLabel))
+			Expect(partition.Name).To(Equal(cnst.BiosPartName))
 			// Should have predictable UUID
 			Expect(strings.ToLower(partition.UUID())).To(Equal(strings.ToLower(uuid.NewV5(uuid.NamespaceURL, cnst.EfiLabel).String())))
 			for i := 1; i < len(disk.Table.GetPartitions()); i++ {

--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -88,7 +88,7 @@ func kairosPartsToDiskfsGPTParts(parts sdkTypes.PartitionList, diskSize int64) [
 				Type:       gpt.EFISystemPartition,
 				Size:       size,                                                         // partition size in bytes
 				GUID:       uuid.NewV5(uuid.NamespaceURL, part.FilesystemLabel).String(), // set know predictable UUID
-				Name:       part.FilesystemLabel,
+				Name:       part.Name,
 				Attributes: 0x1, // system partition flag
 			})
 		} else if part.Name == cnst.BiosPartName {
@@ -99,7 +99,7 @@ func kairosPartsToDiskfsGPTParts(parts sdkTypes.PartitionList, diskSize int64) [
 				Type:       gpt.BIOSBoot,
 				Size:       size,                                                         // partition size in bytes
 				GUID:       uuid.NewV5(uuid.NamespaceURL, part.FilesystemLabel).String(), // set know predictable UUID
-				Name:       part.FilesystemLabel,
+				Name:       part.Name,
 				Attributes: 0x4, // legacy bios bootable flag
 			})
 		} else {
@@ -110,7 +110,7 @@ func kairosPartsToDiskfsGPTParts(parts sdkTypes.PartitionList, diskSize int64) [
 				Type:  gpt.LinuxFilesystem,
 				Size:  size,
 				GUID:  uuid.NewV5(uuid.NamespaceURL, part.FilesystemLabel).String(),
-				Name:  part.FilesystemLabel,
+				Name:  part.Name,
 			})
 		}
 	}


### PR DESCRIPTION
We were using the partion label as the fs label and the fs labe was nto used anywhere