### PR TITLE
Scan /oem the last one

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -173,9 +173,9 @@ func GetConfigScanDirs() []string {
 		"/run/initramfs/live",
 		"/usr/local/cloud-config",
 		"/system/oem",
-		"/oem",
 		"/etc/kairos",    // Default system configuration file https://github.com/kairos-io/kairos/issues/2221
 		"/etc/elemental", // for backwards compatibility
+		"/oem",
 	}
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -170,10 +170,10 @@ func GetGrubModules() []string {
 
 func GetConfigScanDirs() []string {
 	return []string{
-		"/oem",
-		"/system/oem",
-		"/usr/local/cloud-config",
 		"/run/initramfs/live",
+		"/usr/local/cloud-config",
+		"/system/oem",
+		"/oem",
 		"/etc/kairos",    // Default system configuration file https://github.com/kairos-io/kairos/issues/2221
 		"/etc/elemental", // for backwards compatibility
 	}


### PR DESCRIPTION
In case there is bundled configs, plus userdata, the userdata should be read at the end to be able to override any existing configs bundled with the system, as userdata is more dynamic.