### PR TITLE
Fix reset

### DIFF
--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -116,6 +116,9 @@ func (r ResetAction) Run() (err error) {
 	// Reformat state partition
 	// We should expose this under a flag, to reformat state before starting
 	// In case state fs is broken somehow
+	// We used to format it blindly but if something happens between this format and the new image copy down below
+	// You end up with a broken system with no active or passive and reset may not even work at that point
+	// TODO: Either create a flag to do this or ignore it and never format the partition
 	/*
 		if r.spec.FormatState {
 			state := r.spec.Partitions.State

--- a/pkg/action/reset_test.go
+++ b/pkg/action/reset_test.go
@@ -89,7 +89,6 @@ var _ = Describe("Reset action tests", func() {
 		var cmdFail, bootedFrom string
 		var err error
 		BeforeEach(func() {
-
 			Expect(err).ShouldNot(HaveOccurred())
 			cmdFail = ""
 			recoveryImg := filepath.Join(constants.RunningStateDir, "cOS", constants.RecoveryImgFile)
@@ -108,22 +107,24 @@ var _ = Describe("Reset action tests", func() {
 					},
 					{
 						Name:            "device2",
+						FilesystemLabel: "COS_OEM",
+						FS:              "ext4",
+						MountPoint:      "/oem",
+					},
+					{
+						Name:            "device3",
+						FilesystemLabel: "COS_RECOVERY",
+						FS:              "ext4",
+						MountPoint:      "/run/initramfs/cos-state",
+					},
+					{
+						Name:            "device4",
 						FilesystemLabel: "COS_STATE",
 						FS:              "ext4",
 					},
 					{
-						Name:            "device3",
-						FilesystemLabel: "COS_PERSISTENT",
-						FS:              "ext4",
-					},
-					{
-						Name:            "device4",
-						FilesystemLabel: "COS_OEM",
-						FS:              "ext4",
-					},
-					{
 						Name:            "device5",
-						FilesystemLabel: "COS_RECOVERY",
+						FilesystemLabel: "COS_PERSISTENT",
 						FS:              "ext4",
 					},
 				},

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -447,7 +447,6 @@ func NewResetSpec(cfg *Config) (*v1.ResetSpec, error) {
 		return nil, fmt.Errorf("could not read host partitions")
 	}
 	ep := v1.NewElementalPartitionsFromList(parts)
-
 	if efiExists {
 		if ep.EFI == nil {
 			return nil, fmt.Errorf("EFI partition not found")
@@ -480,7 +479,6 @@ func NewResetSpec(cfg *Config) (*v1.ResetSpec, error) {
 	target := ep.State.Disk
 
 	// OEM partition is not a hard requirement for reset unless we have the reset oem flag
-	cfg.Logger.Info(litter.Sdump(ep.OEM))
 	if ep.OEM == nil {
 		// We could have oem in lvm which won't appear in ghw list
 		ep.OEM = partitions.GetPartitionViaDM(cfg.Fs, constants.OEMLabel)

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -350,9 +350,9 @@ func (e *Elemental) DeployImage(img *v1.Image, leaveMounted bool) (info interfac
 			}
 		}
 	} else if img.Label != "" && img.FS != cnst.SquashFs {
-		_, err = e.config.Runner.Run("tune2fs", "-L", img.Label, img.File)
+		out, err := e.config.Runner.Run("tune2fs", "-L", img.Label, img.File)
 		if err != nil {
-			e.config.Logger.Errorf("Failed to apply label %s to %s", img.Label, img.File)
+			e.config.Logger.Errorf("Failed to apply label %s to %s: %s", img.Label, img.File, out)
 			_ = e.config.Fs.Remove(img.File)
 			return nil, err
 		}

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -352,7 +352,7 @@ func (e *Elemental) DeployImage(img *v1.Image, leaveMounted bool) (info interfac
 	} else if img.Label != "" && img.FS != cnst.SquashFs {
 		out, err := e.config.Runner.Run("tune2fs", "-L", img.Label, img.File)
 		if err != nil {
-			e.config.Logger.Errorf("Failed to apply label %s to %s: %s", img.Label, img.File, out)
+			e.config.Logger.Errorf("Failed to apply label %s to %s: %s", img.Label, img.File, string(out))
 			_ = e.config.Fs.Remove(img.File)
 			return nil, err
 		}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -83,6 +83,7 @@ func CopyFile(fs v1.FS, source string, target string) (err error) {
 // Source files are concatenated into target file in the given order.
 // If target is a directory source is copied into that directory using
 // 1st source name file.
+// TODO: Log errors, return errors, whatever but dont ignore them
 func ConcatFiles(fs v1.FS, sources []string, target string) (err error) {
 	if len(sources) == 0 {
 		return fmt.Errorf("Empty sources list")


### PR DESCRIPTION
Seems like witht he older ghw, we were not receiving all the proper partitions and mountpoints and such, so on reset we could blindily try to unmount all partitions and call it a day.

But now we get info about all of them, so doing so will even unmount the current recovery partition, where the reset source is at, thus failing the reset copy.

This patch fixes it by instead of going crazy, making sure we have an order mount/unmount of the proper places at the proper times and we restore everything as is once we are done with it