### PR TITLE
Try to get the flavor on EFI installs

### DIFF
--- a/pkg/utils/grub.go
+++ b/pkg/utils/grub.go
@@ -176,6 +176,18 @@ func (g Grub) Install(target, rootDir, bootDir, grubConf, tty string, efi bool, 
 		if err != nil {
 			g.config.Logger.Warnf("Failed reading os-release from %s: %v", filepath.Join(cnst.ActiveDir, "etc/os-release"), err)
 		}
+		if flavor == "" {
+			// If os-release is gone with our vars, we dont know what flavor are we in, we should know if we are on ubuntu as we need
+			// a workaround for the grub efi install
+			// So lets try to get the info from the normal keys shipped with the os
+			flavorFromId, err := utils.OSRelease("ID", filepath.Join(cnst.ActiveDir, "etc/os-release"))
+			if err != nil {
+				g.config.Logger.Logger.Err(err).Msg("Getting flavor")
+			}
+			if strings.Contains(strings.ToLower(flavorFromId), "ubuntu") {
+				flavor = "ubuntu"
+			}
+		}
 		g.config.Logger.Debugf("Detected Flavor: %s", flavor)
 		// Copy needed files for efi boot
 		// This seems like a chore while we could provide a package for those bundled files as they are just a shim and a grub efi


### PR DESCRIPTION
If somehow our KAIROS_X keys are gone from the system due to something removing them like an upgrade, we wont be able to identify the flavors and we need it if its an ubuntu machine as we do a workaround for EFI installs, otherwise you get a broken grub.

This tries to infer the flavor form the os-release ID field which will exist and check if its ubuntu.

Fixes: https://github.com/kairos-io/kairos/issues/2895