### PR TITLE
Read actual system configs during k8s upgrade

### DIFF
--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -14,6 +14,7 @@ import (
 	config "github.com/kairos-io/kairos-agent/v2/pkg/config"
 	"github.com/kairos-io/kairos-agent/v2/pkg/uki"
 	internalutils "github.com/kairos-io/kairos-agent/v2/pkg/utils"
+	k8sutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/k8s"
 	events "github.com/kairos-io/kairos-sdk/bus"
 	"github.com/kairos-io/kairos-sdk/collector"
 	"github.com/kairos-io/kairos-sdk/utils"
@@ -73,7 +74,7 @@ func Upgrade(
 	// Check and fix dirs if we are under k8s, so we read the actual running system configs instead of only
 	// the container configs
 	// we can run it blindly as it will return an empty string if not under k8s
-	hostdir := internalutils.GetHostDirForK8s()
+	hostdir := k8sutils.GetHostDirForK8s()
 	for _, dir := range dirs {
 		fixedDirs = append(fixedDirs, filepath.Join(hostdir, dir))
 	}

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -853,9 +853,9 @@ func GetSourceSize(config *Config, source *v1.ImageSource) (int64, error) {
 
 		// This is always set for pods running under kubernetes
 		_, underKubernetes := os.LookupEnv("KUBERNETES_SERVICE_HOST")
-		config.Logger.Logger.Debug().Bool("status", underKubernetes).Msg("Running under kubernetes")
 		// Try to get the HOST_DIR in case we are not using the default one
 		hostDir := k8sutils.GetHostDirForK8s()
+		config.Logger.Logger.Debug().Bool("status", underKubernetes).Str("hostdir", hostDir).Msg("Running under kubernetes host directory")
 		err = fsutils.WalkDirFs(config.Fs, source.Value(), func(path string, d fs.DirEntry, err error) error {
 			// If its empty we are just not setting it, so probably out of the k8s upgrade path
 			if hostDir != "" && strings.HasPrefix(path, hostDir) {

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kairos-io/kairos-agent/v2/pkg/constants"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
+	"github.com/kairos-io/kairos-agent/v2/pkg/utils"
 	fsutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
 	"github.com/kairos-io/kairos-agent/v2/pkg/utils/partitions"
 	"github.com/kairos-io/kairos-sdk/collector"
@@ -852,14 +853,9 @@ func GetSourceSize(config *Config, source *v1.ImageSource) (int64, error) {
 
 		// This is always set for pods running under kubernetes
 		_, underKubernetes := os.LookupEnv("KUBERNETES_SERVICE_HOST")
-		config.Logger.Logger.Info().Bool("status", underKubernetes).Msg("Running under kubernetes")
+		config.Logger.Logger.Debug().Bool("status", underKubernetes).Msg("Running under kubernetes")
 		// Try to get the HOST_DIR in case we are not using the default one
-		hostDir := os.Getenv("HOST_DIR")
-		// If we are under kubernetes but the HOST_DIR var is empty, default to /host as system-upgrade-controller mounts
-		// the host in that dir by default
-		if underKubernetes && hostDir == "" {
-			hostDir = "/host"
-		}
+		hostDir := utils.GetHostDirForK8s()
 		err = fsutils.WalkDirFs(config.Fs, source.Value(), func(path string, d fs.DirEntry, err error) error {
 			// If its empty we are just not setting it, so probably out of the k8s upgrade path
 			if hostDir != "" && strings.HasPrefix(path, hostDir) {

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/kairos-io/kairos-agent/v2/pkg/constants"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
-	"github.com/kairos-io/kairos-agent/v2/pkg/utils"
 	fsutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
+	k8sutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/k8s"
 	"github.com/kairos-io/kairos-agent/v2/pkg/utils/partitions"
 	"github.com/kairos-io/kairos-sdk/collector"
 	"github.com/kairos-io/kairos-sdk/ghw"
@@ -855,7 +855,7 @@ func GetSourceSize(config *Config, source *v1.ImageSource) (int64, error) {
 		_, underKubernetes := os.LookupEnv("KUBERNETES_SERVICE_HOST")
 		config.Logger.Logger.Debug().Bool("status", underKubernetes).Msg("Running under kubernetes")
 		// Try to get the HOST_DIR in case we are not using the default one
-		hostDir := utils.GetHostDirForK8s()
+		hostDir := k8sutils.GetHostDirForK8s()
 		err = fsutils.WalkDirFs(config.Fs, source.Value(), func(path string, d fs.DirEntry, err error) error {
 			// If its empty we are just not setting it, so probably out of the k8s upgrade path
 			if hostDir != "" && strings.HasPrefix(path, hostDir) {

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -850,12 +850,11 @@ func GetSourceSize(config *Config, source *v1.ImageSource) (int64, error) {
 		// , which mounts the host root into $HOST_DIR
 		// we should skip that dir when calculating the size as we would be doubling the calculated size
 		// Plus we will hit the usual things when checking a running system. Processes that go away, tmpfiles, etc...
-
 		// This is always set for pods running under kubernetes
 		_, underKubernetes := os.LookupEnv("KUBERNETES_SERVICE_HOST")
 		// Try to get the HOST_DIR in case we are not using the default one
 		hostDir := k8sutils.GetHostDirForK8s()
-		config.Logger.Logger.Debug().Bool("status", underKubernetes).Str("hostdir", hostDir).Msg("Running under kubernetes host directory")
+		config.Logger.Logger.Debug().Bool("status", underKubernetes).Str("hostdir", hostDir).Msg("Kubernetes check")
 		err = fsutils.WalkDirFs(config.Fs, source.Value(), func(path string, d fs.DirEntry, err error) error {
 			// If its empty we are just not setting it, so probably out of the k8s upgrade path
 			if hostDir != "" && strings.HasPrefix(path, hostDir) {

--- a/pkg/config/spec_test.go
+++ b/pkg/config/spec_test.go
@@ -703,7 +703,8 @@ var _ = Describe("GetSourceSize", Label("GetSourceSize"), func() {
 
 		Expect(os.Mkdir(filepath.Join(tempDir, "host"), os.ModePerm)).ToNot(HaveOccurred())
 		Expect(createFileOfSizeInMB(filepath.Join(tempDir, "host", "what.txt"), 200)).ToNot(HaveOccurred())
-		// Set env var like the suc upgrade does
+		// Set env var like the suc upgrade and k8s does to trigger the skip
+		Expect(os.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")).ToNot(HaveOccurred())
 		Expect(os.Setenv("HOST_DIR", filepath.Join(tempDir, "host"))).ToNot(HaveOccurred())
 
 		sizeAfter, err := config.GetSourceSize(conf, imageSource)

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -614,3 +614,22 @@ func CheckFailedInstallation(stateFile string) (bool, error) {
 	}
 	return false, nil
 }
+
+// GetHostDirForK8s returns the base dir where the system is
+// This is because under k8s, we mount the actual system under a dir
+// So we need to know which paths we need to read the configs from
+// if we read them from the root directly, we are actually reading the
+// configs of the upgrade container
+// If not found returns an empty string
+func GetHostDirForK8s() string {
+	var hostdir string
+	_, underKubernetes := os.LookupEnv("KUBERNETES_SERVICE_HOST")
+	// Try to get the HOST_DIR in case we are not using the default one
+	hostDirEnv := os.Getenv("HOST_DIR")
+	// If we are under kubernetes but the HOST_DIR var is empty, default to /host as system-upgrade-controller mounts
+	// the host in that dir by default
+	if underKubernetes && hostDirEnv == "" {
+		hostdir = "/host"
+	}
+	return hostdir
+}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -614,22 +614,3 @@ func CheckFailedInstallation(stateFile string) (bool, error) {
 	}
 	return false, nil
 }
-
-// GetHostDirForK8s returns the base dir where the system is
-// This is because under k8s, we mount the actual system under a dir
-// So we need to know which paths we need to read the configs from
-// if we read them from the root directly, we are actually reading the
-// configs of the upgrade container
-// If not found returns an empty string
-func GetHostDirForK8s() string {
-	var hostdir string
-	_, underKubernetes := os.LookupEnv("KUBERNETES_SERVICE_HOST")
-	// Try to get the HOST_DIR in case we are not using the default one
-	hostDirEnv := os.Getenv("HOST_DIR")
-	// If we are under kubernetes but the HOST_DIR var is empty, default to /host as system-upgrade-controller mounts
-	// the host in that dir by default
-	if underKubernetes && hostDirEnv == "" {
-		hostdir = "/host"
-	}
-	return hostdir
-}

--- a/pkg/utils/k8s/common.go
+++ b/pkg/utils/k8s/common.go
@@ -1,0 +1,22 @@
+package k8s
+
+import "os"
+
+// GetHostDirForK8s returns the base dir where the system is
+// This is because under k8s, we mount the actual system under a dir
+// So we need to know which paths we need to read the configs from
+// if we read them from the root directly, we are actually reading the
+// configs of the upgrade container
+// If not found returns an empty string
+func GetHostDirForK8s() string {
+	var hostdir string
+	_, underKubernetes := os.LookupEnv("KUBERNETES_SERVICE_HOST")
+	// Try to get the HOST_DIR in case we are not using the default one
+	hostDirEnv := os.Getenv("HOST_DIR")
+	// If we are under kubernetes but the HOST_DIR var is empty, default to /host as system-upgrade-controller mounts
+	// the host in that dir by default
+	if underKubernetes && hostDirEnv == "" {
+		hostdir = "/host"
+	}
+	return hostdir
+}

--- a/pkg/utils/k8s/common.go
+++ b/pkg/utils/k8s/common.go
@@ -21,7 +21,7 @@ func GetHostDirForK8s() string {
 			return "/host"
 		}
 	} else {
-		// We return an empty string so any filepath.join does nto alter the paths
+		// We return an empty string so any filepath.join does not alter the paths
 		return ""
 	}
 }

--- a/pkg/utils/k8s/common.go
+++ b/pkg/utils/k8s/common.go
@@ -9,14 +9,19 @@ import "os"
 // configs of the upgrade container
 // If not found returns an empty string
 func GetHostDirForK8s() string {
-	var hostdir string
 	_, underKubernetes := os.LookupEnv("KUBERNETES_SERVICE_HOST")
 	// Try to get the HOST_DIR in case we are not using the default one
 	hostDirEnv := os.Getenv("HOST_DIR")
 	// If we are under kubernetes but the HOST_DIR var is empty, default to /host as system-upgrade-controller mounts
 	// the host in that dir by default
-	if underKubernetes && hostDirEnv == "" {
-		hostdir = "/host"
+	if underKubernetes {
+		if hostDirEnv != "" {
+			return hostDirEnv
+		} else {
+			return "/host"
+		}
+	} else {
+		// We return an empty string so any filepath.join does nto alter the paths
+		return ""
 	}
-	return hostdir
 }


### PR DESCRIPTION
Because under k8s the actual real system is mounted into a dir, the configs that we are reading by default are not the ones in the system but the ones on the upgrade container, which is running under /

This patch introduces a check to see if we are running under k8s, and if we are it tries to get the host dir where the system is mounted. then it will prepend that host dir to the config scan so we can actually scan the system configs.

Int he case we are out of k8s, this should not affect the upgrade as it will return an empty string resulting in the ususal dirs being scanned

Fixes https://github.com/kairos-io/kairos/issues/2944 and probably others lol