### PR TITLE
Add sort-key during install based on the entry name

### DIFF
--- a/pkg/uki/common.go
+++ b/pkg/uki/common.go
@@ -177,7 +177,7 @@ func AddSystemdConfSortKey(fs v1.FS, artifactDir string, log sdkTypes.KairosLogg
 			log.Logger.Debug().Str("path", path).Msg("Adding sort key to file")
 			conf, err := sdkutils.SystemdBootConfReader(path)
 			if err != nil {
-				log.Errorf("Error reading conf file to extract values %s: %s", path)
+				log.Errorf("Error reading conf file to extract values %s: %s", conf, path)
 			}
 			// Now check and put the proper sort key
 			var sortKey string
@@ -204,7 +204,7 @@ func AddSystemdConfSortKey(fs v1.FS, artifactDir string, log sdkTypes.KairosLogg
 			}
 			log.Logger.Trace().Str("contents", litter.Sdump(conf)).Str("path", path).Msg("Final values for conf file")
 
-			return os.WriteFile(path, []byte(newContents), os.ModePerm)
+			return os.WriteFile(path, []byte(newContents), 0600)
 		}
 
 		return nil

--- a/pkg/uki/install.go
+++ b/pkg/uki/install.go
@@ -181,6 +181,12 @@ func (i *InstallAction) Run() (err error) {
 		return fmt.Errorf("removing artifact set with role %s: %w", UnassignedArtifactRole, err)
 	}
 
+	// add sort key to all files
+	err = AddSystemdConfSortKey(i.cfg.Fs, i.spec.Partitions.EFI.MountPoint, i.cfg.Logger)
+	if err != nil {
+		i.cfg.Logger.Warnf("adding sort key: %s", err.Error())
+	}
+
 	// Add boot assessment to files by appending +3 to the name
 	err = utils.AddBootAssessment(i.cfg.Fs, i.spec.Partitions.EFI.MountPoint, i.cfg.Logger)
 	if err != nil {

--- a/pkg/uki/reset.go
+++ b/pkg/uki/reset.go
@@ -81,6 +81,12 @@ func (r *ResetAction) Run() (err error) {
 		return fmt.Errorf("copying recovery to active: %w", err)
 	}
 
+	// add sort key to all files
+	err = AddSystemdConfSortKey(r.cfg.Fs, r.spec.Partitions.EFI.MountPoint, r.cfg.Logger)
+	if err != nil {
+		r.cfg.Logger.Warnf("adding sort key: %s", err.Error())
+	}
+
 	// Add boot assessment to files by appending +3 to the name
 	err = elementalUtils.AddBootAssessment(r.cfg.Fs, r.spec.Partitions.EFI.MountPoint, r.cfg.Logger)
 	if err != nil {

--- a/pkg/uki/upgrade.go
+++ b/pkg/uki/upgrade.go
@@ -109,6 +109,13 @@ func (i *UpgradeAction) Run() (err error) {
 		i.cfg.Logger.Errorf("removing artifact set: %s", err.Error())
 		return fmt.Errorf("removing artifact set: %w", err)
 	}
+
+	// add sort key to all files
+	err = AddSystemdConfSortKey(i.cfg.Fs, i.spec.EfiPartition.MountPoint, i.cfg.Logger)
+	if err != nil {
+		i.cfg.Logger.Warnf("adding sort key: %s", err.Error())
+	}
+
 	// Add boot assessment to files by appending +3 to the name
 	err = elementalUtils.AddBootAssessment(i.cfg.Fs, i.spec.EfiPartition.MountPoint, i.cfg.Logger)
 	if err != nil {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8a2abf22-0274-4386-8148-fac90d2a6436)


Fixes https://github.com/kairos-io/kairos/issues/3040