### PR TITLE
Use extensions dir path as source

### DIFF
--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -39,7 +39,7 @@ func (b BundlePostInstall) Run(c config.Config, _ v1.Spec) error {
 		return err
 	}
 
-	cmd := exec.Command("rsync", "-aqAX", "/var/lib/extensions", "/usr/local/.state/var-lib-extensions.bind")
+	cmd := exec.Command("rsync", "-aqAX", "/var/lib/extensions/", "/usr/local/.state/var-lib-extensions.bind")
 	_, err = cmd.CombinedOutput()
 	if c.FailOnBundleErrors && err != nil {
 		return err


### PR DESCRIPTION
Otherwise it will copy the dir itself and we just want to copy the contents of the dir

Fixes https://github.com/kairos-io/kairos/issues/3098

Co-authored-by: [ChrisPbb](https://github.com/ChrisPbb)