### PR TITLE
feat: allow to override standard cloud init paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -667,6 +667,10 @@ The validate command expects a configuration file as its only argument. Local fi
 				Name:  "cloud-init-paths",
 				Usage: "Extra paths to add to the run stage",
 			},
+			&cli.StringSliceFlag{
+				Name:  "override-cloud-init-paths",
+				Usage: "Paths to use when running the stage",
+			},
 			&cli.BoolFlag{
 				Name:    "analyze",
 				Usage:   "Only print the modules that would run in the order they would run",
@@ -687,9 +691,14 @@ The validate command expects a configuration file as its only argument. Local fi
 			config, err := agentConfig.Scan(collector.Directories(constants.GetYipConfigDirs()...), collector.NoLogs)
 			config.Strict = c.Bool("strict")
 
+			if len(c.StringSlice("override-cloud-init-paths")) > 0 {
+				config.CloudInitPaths = c.StringSlice("override-cloud-init-paths")
+			}
+
 			if len(c.StringSlice("cloud-init-paths")) > 0 {
 				config.CloudInitPaths = append(config.CloudInitPaths, c.StringSlice("cloud-init-paths")...)
 			}
+
 			if c.Bool("debug") {
 				config.Logger.SetLevel("debug")
 			}

--- a/main.go
+++ b/main.go
@@ -669,7 +669,7 @@ The validate command expects a configuration file as its only argument. Local fi
 			},
 			&cli.StringSliceFlag{
 				Name:  "override-cloud-init-paths",
-				Usage: "Paths to use when running the stage",
+				Usage: "Override paths to use when running the stage, removing defaults",
 			},
 			&cli.BoolFlag{
 				Name:    "analyze",

--- a/main.go
+++ b/main.go
@@ -669,7 +669,7 @@ The validate command expects a configuration file as its only argument. Local fi
 			},
 			&cli.StringSliceFlag{
 				Name:  "override-cloud-init-paths",
-				Usage: "Override paths to use when running the stage, removing defaults",
+				Usage: "Override paths to use when running the stage, removing defaults. Supercedes --cloud-init-paths",
 			},
 			&cli.BoolFlag{
 				Name:    "analyze",
@@ -691,12 +691,12 @@ The validate command expects a configuration file as its only argument. Local fi
 			config, err := agentConfig.Scan(collector.Directories(constants.GetYipConfigDirs()...), collector.NoLogs)
 			config.Strict = c.Bool("strict")
 
-			if len(c.StringSlice("override-cloud-init-paths")) > 0 {
-				config.CloudInitPaths = c.StringSlice("override-cloud-init-paths")
-			}
-
 			if len(c.StringSlice("cloud-init-paths")) > 0 {
 				config.CloudInitPaths = append(config.CloudInitPaths, c.StringSlice("cloud-init-paths")...)
+			}
+
+			if len(c.StringSlice("override-cloud-init-paths")) > 0 {
+				config.CloudInitPaths = c.StringSlice("override-cloud-init-paths")
 			}
 
 			if c.Bool("debug") {


### PR DESCRIPTION
This is needed in order to avoid loops