### PR TITLE
Disable xattrs on rsync

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -185,7 +185,7 @@ func SyncData(log sdkTypes.KairosLogger, runner v1.Runner, fs v1.FS, source stri
 		"--human-readable",
 		"--archive", // recursive, symbolic links, permissions, owner, group, modification times, device files, special files
 		"--acls",    // preserve ACLS and permissions
-		"-U",        // preserve access times
+		"--atimes",  // preserve access times
 	}
 
 	for _, e := range excludes {

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -182,12 +182,9 @@ func SyncData(log sdkTypes.KairosLogger, runner v1.Runner, fs v1.FS, source stri
 		"--progress",
 		"--partial",
 		"--human-readable",
-		"--archive",
-		"--acls",
-		"-t",
-		"-U",
-		"-o",
-		"-g",
+		"--archive", // recursive, symbolic links, permissions, owner, group, modification times, device files, special files
+		"--acls",    // preserve ACLS and permissions
+		"-U",        // preserve access times
 	}
 
 	for _, e := range excludes {

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -178,7 +178,17 @@ func SyncData(log sdkTypes.KairosLogger, runner v1.Runner, fs v1.FS, source stri
 	}
 
 	log.Infof("Starting rsync...")
-	args := []string{"--progress", "--partial", "--human-readable", "--archive", "--xattrs", "--acls"}
+	args := []string{
+		"--progress",
+		"--partial",
+		"--human-readable",
+		"--archive",
+		"--acls",
+		"-t",
+		"-U",
+		"-o",
+		"-g",
+	}
 
 	for _, e := range excludes {
 		args = append(args, fmt.Sprintf("--exclude=%s", e))

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -178,6 +178,7 @@ func SyncData(log sdkTypes.KairosLogger, runner v1.Runner, fs v1.FS, source stri
 	}
 
 	log.Infof("Starting rsync...")
+	// TODO: copy xattr if possible or needed for selinux contexts? Or do we just relabel those on first boot?
 	args := []string{
 		"--progress",
 		"--partial",


### PR DESCRIPTION
For systems with selinux enabled, this makes impossible to generate the proper files as its being blocked

This fixes it as tested on my Fedora with selinux.

Fixes #https://github.com/kairos-io/AuroraBoot/issues/196