### PR TITLE
Change webui assets path to be relative

### DIFF
--- a/internal/webui/public/index.html
+++ b/internal/webui/public/index.html
@@ -6,25 +6,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <!-- Bootstrap CSS -->
-  <link rel="stylesheet" href="/node_modules/bootstrap/dist/css/bootstrap.min.css" crossorigin="anonymous">
+  <link rel="stylesheet" href="./node_modules/bootstrap/dist/css/bootstrap.min.css" crossorigin="anonymous">
   
   <!-- Font awesome -->
-  <link rel="stylesheet" href="/node_modules/@fortawesome/fontawesome-free/css/all.css" crossorigin="anonymous">
+  <link rel="stylesheet" href="./node_modules/@fortawesome/fontawesome-free/css/all.css" crossorigin="anonymous">
 
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
   <link rel="shortcut icon" href="/favicon.ico">
 
   <!-- CodeMirror -->
-  <link rel="stylesheet" href="/node_modules/codemirror/lib/codemirror.css">
-  <script src="/node_modules/codemirror/lib/codemirror.js"></script>
-  <script src="/node_modules/codemirror/mode/yaml/yaml.js"></script>
-  <link rel="stylesheet" href="/node_modules/codemirror/theme/material.css">
+  <link rel="stylesheet" href="./node_modules/codemirror/lib/codemirror.css">
+  <script src="./node_modules/codemirror/lib/codemirror.js"></script>
+  <script src="./node_modules/codemirror/mode/yaml/yaml.js"></script>
+  <link rel="stylesheet" href="./node_modules/codemirror/theme/material.css">
 
   <!-- Add the yaml-js library -->
-  <script type="text/javascript" src="/node_modules/yamljs/dist/yaml.min.js"></script>
+  <script type="text/javascript" src="./node_modules/yamljs/dist/yaml.min.js"></script>
 
   <!-- Alpine.js -->
-  <script defer src="/node_modules/alpinejs/dist/cdn.min.js"></script>
+  <script defer src="./node_modules/alpinejs/dist/cdn.min.js"></script>
   <style>
     .navbar {
       background-color: #ee5007;
@@ -129,9 +129,9 @@
 
   <!-- Optional JavaScript -->
   <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-  <script src="/node_modules/jquery/dist/jquery.slim.min.js" crossorigin="anonymous"></script>
-  <script src="/node_modules/@popperjs/core/dist/umd/popper.min.js" crossorigin="anonymous"></script>
-  <script src="/node_modules/bootstrap/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>
+  <script src="./node_modules/jquery/dist/jquery.slim.min.js" crossorigin="anonymous"></script>
+  <script src="./node_modules/@popperjs/core/dist/umd/popper.min.js" crossorigin="anonymous"></script>
+  <script src="./node_modules/bootstrap/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>
   
   <footer class="bg-light py-3 mt-5 d-flex justify-content-center">
     <div class="container mx-auto">


### PR DESCRIPTION
This allows me to do some complex config with my local server. For example if I spin up a vm and it gets the ip 192.168.122.137 within the same host I can simply access the webui from 192.168.122.137:8080 but let's say that I want to access it though a vpn like tailscale then I do something like this http://zeno/192.168.122.137/ which gets proxied to http://192.168.122.137:8080 which works fine, except for the assets because when the page gets rendered it tries to get them from http://zeno/node_modules

I'll also switch this to be done with a build in the future instead of accessing from node_modules directly