### PR TITLE
Disable atimes in rsync

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -185,7 +185,6 @@ func SyncData(log sdkTypes.KairosLogger, runner v1.Runner, fs v1.FS, source stri
 		"--human-readable",
 		"--archive", // recursive, symbolic links, permissions, owner, group, modification times, device files, special files
 		"--acls",    // preserve ACLS and permissions
-		"--atimes",  // preserve access times
 	}
 
 	for _, e := range excludes {


### PR DESCRIPTION
Some very old distros like ubuntu dont have that option