### PR TITLE
Use grub binaries and libs from rootfs

### DIFF
--- a/internal/agent/hooks/finish.go
+++ b/internal/agent/hooks/finish.go
@@ -43,7 +43,11 @@ func (k Finish) Run(c config.Config, spec v1.Spec) error {
 		c.Logger.Logger.Info().Msg("Finished encrypt hook")
 	}
 
-	// Now that we have everything encrypted and ready if needed
+	// Now that we have everything encrypted and ready to mount if needed
+	err = GrubPostInstallOptions{}.Run(c, spec)
+	if err != nil {
+		return err
+	}
 	err = BundlePostInstall{}.Run(c, spec)
 	if err != nil {
 		c.Logger.Logger.Warn().Err(err).Msg("could not copy run bundles post install")

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -56,7 +56,7 @@ func grubOptions(c config.Config, opts map[string]string) error {
 			return err
 		}
 	}
-	err = utils.SetPersistentVariables(filepath.Join(runtime.OEM.MountPoint, "grubenv"), opts, c.Fs)
+	err = utils.SetPersistentVariables(filepath.Join(runtime.OEM.MountPoint, "grubenv"), opts, &c)
 	if err != nil {
 		c.Logger.Logger.Error().Err(err).Msg("Failed to set grub options")
 	}

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -2,7 +2,7 @@ package hook
 
 import (
 	"fmt"
-	config "github.com/kairos-io/kairos-agent/v2/pkg/config"
+	"github.com/kairos-io/kairos-agent/v2/pkg/config"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	"github.com/kairos-io/kairos-sdk/utils"
 	"strings"
@@ -15,8 +15,7 @@ type Interface interface {
 // FinishInstall is a list of hooks that run when the install process is finished completely.
 // Its mean for options that are not related to the install process itself
 var FinishInstall = []Interface{
-	&GrubOptions{}, // Set custom GRUB options in OEM partition
-	&Lifecycle{},   // Handles poweroff/reboot by config options
+	&Lifecycle{}, // Handles poweroff/reboot by config options
 }
 
 // FinishReset is a list of hooks that run when the reset process is finished completely.
@@ -46,7 +45,7 @@ var FinishUKIInstall = []Interface{
 // PostInstall is a list of hooks that run after the install process has run.
 // Runs things that need to be done before we run other post install stages like
 // encrypting partitions, copying the install logs or installing bundles
-// Most of this options are optional so they are not run by default unless specified int he config
+// Most of this options are optional so they are not run by default unless specified in the config
 var PostInstall = []Interface{
 	&Finish{},
 }

--- a/pkg/action/bootentries.go
+++ b/pkg/action/bootentries.go
@@ -60,7 +60,7 @@ func selectBootEntryGrub(cfg *config.Config, entry string) error {
 	vars := map[string]string{
 		"next_entry": entry,
 	}
-	err = utils.SetPersistentVariables("/oem/grubenv", vars, cfg.Fs)
+	err = utils.SetPersistentVariables("/oem/grubenv", vars, cfg)
 	if err != nil {
 		cfg.Logger.Errorf("could not set default boot entry: %s\n", err)
 		return err

--- a/pkg/action/bootentries_test.go
+++ b/pkg/action/bootentries_test.go
@@ -694,7 +694,7 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 				err = SelectBootEntry(config, "kairos")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(memLog.String()).To(ContainSubstring("Default boot entry set to kairos"))
-				variables, err := utils.ReadPersistentVariables("/oem/grubenv", fs)
+				variables, err := utils.ReadPersistentVariables("/oem/grubenv", config)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(variables["next_entry"]).To(Equal("kairos"))
 			})

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -584,7 +584,7 @@ func (e Elemental) SetDefaultGrubEntry(partMountPoint string, imgMountPoint stri
 	return utils.SetPersistentVariables(
 		filepath.Join(partMountPoint, cnst.GrubOEMEnv),
 		map[string]string{"default_menu_entry": defaultEntry},
-		e.config.Fs,
+		e.config,
 	)
 }
 

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -848,7 +848,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			el := elemental.NewElemental(config)
 			Expect(config.Fs.Mkdir("/tmp", cnst.DirPerm)).To(BeNil())
 			Expect(el.SetDefaultGrubEntry("/tmp", "/imgMountpoint", "dio")).To(BeNil())
-			varsParsed, err := utils.ReadPersistentVariables(filepath.Join("/tmp", cnst.GrubOEMEnv), config.Fs)
+			varsParsed, err := utils.ReadPersistentVariables(filepath.Join("/tmp", cnst.GrubOEMEnv), config)
 			Expect(err).To(BeNil())
 			Expect(varsParsed["default_menu_entry"]).To(Equal("dio"))
 		})
@@ -856,7 +856,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			el := elemental.NewElemental(config)
 			Expect(config.Fs.Mkdir("/mountpoint", cnst.DirPerm)).To(BeNil())
 			Expect(el.SetDefaultGrubEntry("/mountpoint", "/imgMountPoint", "")).To(BeNil())
-			_, err := utils.ReadPersistentVariables(filepath.Join("/tmp", cnst.GrubOEMEnv), config.Fs)
+			_, err := utils.ReadPersistentVariables(filepath.Join("/tmp", cnst.GrubOEMEnv), config)
 			// Because it didnt do anything due to the entry being empty, the file should not be there
 			Expect(err).ToNot(BeNil())
 			_, err = config.Fs.Stat(filepath.Join("/tmp", cnst.GrubOEMEnv))
@@ -871,7 +871,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 
 			el := elemental.NewElemental(config)
 			Expect(el.SetDefaultGrubEntry("/mountpoint", "/imgMountPoint", "")).To(BeNil())
-			varsParsed, err := utils.ReadPersistentVariables(filepath.Join("/mountpoint", cnst.GrubOEMEnv), config.Fs)
+			varsParsed, err := utils.ReadPersistentVariables(filepath.Join("/mountpoint", cnst.GrubOEMEnv), config)
 			Expect(err).To(BeNil())
 			Expect(varsParsed["default_menu_entry"]).To(Equal("test"))
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -804,9 +804,9 @@ var _ = Describe("Utils", Label("utils"), func() {
 				defer os.Remove(temp.Name())
 				Expect(utils.SetPersistentVariables(
 					temp.Name(), map[string]string{"key1": "value1", "key2": "value2"},
-					config.Fs,
+					config,
 				)).To(BeNil())
-				readVars, err := utils.ReadPersistentVariables(temp.Name(), config.Fs)
+				readVars, err := utils.ReadPersistentVariables(temp.Name(), config)
 				Expect(err).To(BeNil())
 				Expect(readVars["key1"]).To(Equal("value1"))
 				Expect(readVars["key2"]).To(Equal("value2"))
@@ -814,7 +814,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 			It("Fails setting variables", func() {
 				e := utils.SetPersistentVariables(
 					"badfilenopath", map[string]string{"key1": "value1"},
-					config.Fs,
+					config,
 				)
 				Expect(e).NotTo(BeNil())
 			})


### PR DESCRIPTION
We should not default to use the underlying OS files and binaries for
grub installs as we may be on a takeover scenario in which the
underlying OS does not provide the needed files.

This moves the grub binary and files to be provided by the source rootfs
and moves the grubOptions hook to use the go libraries directly instead
of shelling out to another binary

This also move the grub hook to use our existing go code instead of shelling out to grub2-editenv and moves the hook into the finish hooks, as it writes into OEM, on an encrypted disk it may not have access to the unencrypted partition, thus not being able to write to the real OEM.

This also brings a small fix in which we could be overwriting the existing vars as we didnt read the grub vars file before writing it, so there could potentially be a shipped file in there that we were fully overwriting.

Fixes https://github.com/kairos-io/kairos/issues/3330

Signed-off-by: Itxaka <itxaka@kairos.io>