### PR TITLE
Fix mountpoint in grub hook

### DIFF
--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -65,9 +65,9 @@ func grubOptions(c config.Config, opts map[string]string) error {
 	} else {
 		c.Logger.Logger.Debug().Msg("OEM partition already mounted")
 	}
-	err = utils.SetPersistentVariables(filepath.Join(runtime.OEM.MountPoint, "grubenv"), opts, &c)
+	err = utils.SetPersistentVariables(filepath.Join(cnst.OEMPath, "grubenv"), opts, &c)
 	if err != nil {
-		c.Logger.Logger.Error().Err(err).Msg("Failed to set grub options")
+		c.Logger.Logger.Error().Err(err).Str("grubfile", filepath.Join(cnst.OEMPath, "grubenv")).Msg("Failed to set grub options")
 	}
 	return err
 }


### PR DESCRIPTION
We were using the runtime.OEM.mountpoint to write the file, but if the OEM was not mounted, the runtime is not updated, thus the mountpoint ends up empty adn we try to write to the root fs.

Instead, as we are explicitely mounting it under OEMPath, use that for the write path so no matter if runtime is updated or not