### PR TITLE
Fix upgrade not remounting properly

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -173,11 +173,11 @@ func (u *UpgradeAction) Run() (err error) {
 		// Create the dir otherwise the check for mounted dir fails
 		_ = fsutils.MkdirAll(u.config.Fs, persistentPart.MountPoint, constants.DirPerm)
 		if mnt, err := utils.IsMounted(u.config, persistentPart); !mnt && err == nil {
-			u.Debug("mounting persistent partition")
 			umount, err = e.MountRWPartition(persistentPart)
 			if err != nil {
 				u.config.Logger.Warnf("could not mount persistent partition: %s", err.Error())
 			}
+			cleanup.Push(umount)
 		}
 	}
 

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -182,7 +182,7 @@ func (e Elemental) MountRWPartition(part *types.Partition) (umount func() error,
 		umount = func() error {
 			e.config.Logger.Debugf("Remounting partition %s as read-only", part.FilesystemLabel)
 			// Remount with bind and read-only options so we avoid in use errors
-			return syscall.Mount(part.MountPoint, part.MountPoint, "", syscall.MS_REMOUNT|syscall.MS_RDONLY|syscall.MS_BIND, "")
+			return e.config.Syscall.Mount(part.MountPoint, part.MountPoint, "", syscall.MS_REMOUNT|syscall.MS_RDONLY|syscall.MS_BIND, "")
 		}
 	} else {
 		err = e.MountPartition(part, "rw")

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -179,7 +179,11 @@ func (e Elemental) MountRWPartition(part *types.Partition) (umount func() error,
 			e.config.Logger.Errorf("failed mounting %s partition: %v", part.Name, err)
 			return nil, err
 		}
-		umount = func() error { return e.MountPartition(part, "remount", "ro") }
+		umount = func() error {
+			e.config.Logger.Debugf("Remounting partition %s as read-only", part.FilesystemLabel)
+			// Remount with bind and read-only options so we avoid in use errors
+			return syscall.Mount(part.MountPoint, part.MountPoint, "", syscall.MS_REMOUNT|syscall.MS_RDONLY|syscall.MS_BIND, "")
+		}
 	} else {
 		err = e.MountPartition(part, "rw")
 		if err != nil {

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -142,10 +142,8 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			Expect(lst[1].Opts).To(Equal([]string{"remount", "rw"}))
 
 			Expect(umount()).ShouldNot(HaveOccurred())
-			lst, _ = mounter.List()
-			// Increased once more to remount read-onply
-			Expect(len(lst)).To(Equal(3))
-			Expect(lst[2].Opts).To(Equal([]string{"remount", "ro"}))
+			// This went to syscall so it wont appears on the mounter list
+			Expect(syscall.WasMountCalledWith(parts.OEM.MountPoint, parts.OEM.MountPoint, "", unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_BIND, "")).To(BeTrue())
 		})
 		It("Fails to mount a partition", func() {
 			mounter.ErrorOnMount = true


### PR DESCRIPTION
Looks like the mount lib did not called the proper options on the remount AND we couold not easily remount RO the state partition.

Instead, after upgrade, just remount with bind so its immidiatly RO and we avoid in use errors.

This also adds a umount/remount for the persistent partition during upgrade if it was mounted by us, to not leave stuff around

Fix https://github.com/kairos-io/kairos/issues/3416