### PR TITLE
Use the upstream yip executor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kairos-io/kairos-agent/v2
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
@@ -38,7 +38,6 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/go-github/v69 v69.2.0
-	github.com/google/go-github/v72 v72.0.0
 	github.com/twpayne/go-vfs/v5 v5.0.4
 	github.com/urfave/cli/v2 v2.27.6
 )

--- a/go.sum
+++ b/go.sum
@@ -230,7 +230,6 @@ github.com/google/go-containerregistry v0.20.5 h1:4RnlYcDs5hoA++CeFjlbZ/U9Yp1EuW
 github.com/google/go-containerregistry v0.20.5/go.mod h1:Q14vdOOzug02bwnhMkZKD4e30pDaD9W65qzXpyzF49E=
 github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
 github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
-github.com/google/go-github/v72 v72.0.0/go.mod h1:WWtw8GMRiL62mvIquf1kO3onRHeWWKmK01qdCY8c5fg=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
@@ -384,6 +383,7 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=

--- a/pkg/cloudinit/cloudinit.go
+++ b/pkg/cloudinit/cloudinit.go
@@ -34,35 +34,7 @@ type YipCloudInitRunner struct {
 // NewYipCloudInitRunner returns a default yip cloud init executor with the Elemental plugin set.
 // It accepts a logger which is used inside the runner.
 func NewYipCloudInitRunner(l sdkTypes.KairosLogger, r v1.Runner, fs vfs.FS) *YipCloudInitRunner {
-	exec := executor.NewExecutor(
-		executor.WithConditionals(
-			plugins.NodeConditional,
-			plugins.IfConditional,
-		),
-		executor.WithLogger(l),
-		executor.WithPlugins(
-			// Note, the plugin execution order depends on the order passed here
-			plugins.DNS,
-			plugins.Download,
-			plugins.Git,
-			plugins.Entities,
-			plugins.EnsureDirectories,
-			plugins.EnsureFiles,
-			plugins.Commands,
-			plugins.DeleteEntities,
-			plugins.Hostname,
-			plugins.Sysctl,
-			plugins.User,
-			plugins.SSH,
-			plugins.LoadModules,
-			plugins.Timesyncd,
-			plugins.Systemctl,
-			plugins.Environment,
-			plugins.SystemdFirstboot,
-			plugins.DataSources,
-			plugins.Layout,
-		),
-	)
+	exec := executor.NewExecutor(executor.WithLogger(l))
 	return &YipCloudInitRunner{
 		exec: exec, fs: fs,
 		console: newCloudInitConsole(l, r),


### PR DESCRIPTION
It already has all the needed stuff like layout plugin which we used to have it under the kairos-agent itself, but it was upstreamed, so this allows us to be closer to upstream yip, for example for plugins added or new conditionals