### PR TITLE
feat: add support for upgrades via OCI files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,11 +35,10 @@ require (
 )
 
 require (
+	github.com/containerd/containerd v1.7.27
 	github.com/distribution/reference v0.6.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/go-github/v69 v69.2.0
-	github.com/google/go-github/v73 v73.0.0
-	github.com/stretchr/testify v1.10.0
 	github.com/twpayne/go-vfs/v5 v5.0.4
 	github.com/urfave/cli/v2 v2.27.7
 )
@@ -68,7 +67,6 @@ require (
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/containerd/cgroups/v3 v3.0.5 // indirect
 	github.com/containerd/console v1.0.5 // indirect
-	github.com/containerd/containerd v1.7.27 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -78,7 +76,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denisbrodbeck/machineid v1.0.1 // indirect
 	github.com/dgryski/go-camellia v0.0.0-20191119043421-69a8a13fb23d // indirect
 	github.com/disintegration/imaging v1.6.2 // indirect
@@ -160,7 +157,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/xattr v0.4.9 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/qeesung/image2ascii v1.0.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
@@ -183,7 +179,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/swaggest/jsonschema-go v0.3.62 // indirect
 	github.com/swaggest/refl v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ github.com/google/go-containerregistry v0.20.6 h1:cvWX87UxxLgaH76b4hIvya6Dzz9qHB
 github.com/google/go-containerregistry v0.20.6/go.mod h1:T0x8MuoAoKX/873bkeSfLD2FAkwCDf9/HZgsFJ02E2Y=
 github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
 github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
-github.com/google/go-github/v72 v72.0.0/go.mod h1:WWtw8GMRiL62mvIquf1kO3onRHeWWKmK01qdCY8c5fg=
-github.com/google/go-github/v73 v73.0.0/go.mod h1:fa6w8+/V+edSU0muqdhCVY7Beh1M8F1IlQPZIANKIYw=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
@@ -474,8 +472,6 @@ github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnj
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.9.4-0.20241118143825-d1e633264448 h1:4T/wluVIsyQ0Kqamo3he0Q0FhZG7CBd5LJgb4KOmftM=
-github.com/sirupsen/logrus v1.9.4-0.20241118143825-d1e633264448/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.4-0.20250620175740-70b809335b84 h1:/yEVyz1i461qtBUR6Qpwf48rWhKJ5A6DlROJIq70gI4=
 github.com/sirupsen/logrus v1.9.4-0.20250620175740-70b809335b84/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
@@ -776,8 +772,6 @@ howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
-k8s.io/mount-utils v0.33.1 h1:hodPhfyoK+gG0SgnYwx1iPrlnpaESZiJ9GFzF5V/imE=
-k8s.io/mount-utils v0.33.1/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
 k8s.io/mount-utils v0.33.2 h1:mZAFhoGs/MwJziVlUpA072vqMhXRc0LGl/W3wybLP20=
 k8s.io/mount-utils v0.33.2/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func ReleasesToOutput(rels []string, output string) []string {
 
 var sourceFlag = cli.StringFlag{
 	Name:  "source",
-	Usage: "Source for upgrade. Composed of `type:address`. Accepts `file:`,`dir:` or `oci:` for the type of source.\nFor example `file:/var/share/myimage.tar`, `dir:/tmp/extracted` or `oci:repo/image:tag`",
+	Usage: "Source for upgrade. Composed of `type:address`. Accepts `file:`,`dir:` `oci:`,or `ocifile:` for the type of source.\nFor example `ocifile:/var/share/myimage.tar`, `dir:/tmp/extracted` or `oci:repo/image:tag`",
 }
 
 var cmds = []*cli.Command{
@@ -1209,12 +1209,12 @@ func validateSource(source string) error {
 		return nil
 	}
 
-	r, err := regexp.Compile(`^oci:|^dir:|^file:|^ocitar:`)
+	r, err := regexp.Compile(`^oci:|^dir:|^file:|^ocifile:`)
 	if err != nil {
 		return err
 	}
 	if !r.MatchString(source) {
-		return fmt.Errorf("source %s does not match any of oci:, dir:, file: or ocitar: ", source)
+		return fmt.Errorf("source %s does not match any of oci:, dir:, file: or ocifile: ", source)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -1209,12 +1209,12 @@ func validateSource(source string) error {
 		return nil
 	}
 
-	r, err := regexp.Compile(`^oci:|^dir:|^file:`)
+	r, err := regexp.Compile(`^oci:|^dir:|^file:|^ocitar:`)
 	if err != nil {
 		return err
 	}
 	if !r.MatchString(source) {
-		return fmt.Errorf("source %s does not match any of oci:, dir: or file: ", source)
+		return fmt.Errorf("source %s does not match any of oci:, dir:, file: or ocitar: ", source)
 	}
 
 	return nil

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -17,6 +17,7 @@ limitations under the License.
 package elemental
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/kairos-io/kairos-sdk/types"
@@ -24,13 +25,17 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/containerd/containerd/archive"
 	"github.com/diskfs/go-diskfs/partition/gpt"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	agentConfig "github.com/kairos-io/kairos-agent/v2/pkg/config"
 	cnst "github.com/kairos-io/kairos-agent/v2/pkg/constants"
 	"github.com/kairos-io/kairos-agent/v2/pkg/partitioner"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	"github.com/kairos-io/kairos-agent/v2/pkg/utils"
-	"github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
+	fsutils "github.com/kairos-io/kairos-agent/v2/pkg/utils/fs"
 	"github.com/kairos-io/kairos-agent/v2/pkg/utils/loop"
 )
 
@@ -409,6 +414,69 @@ func (e *Elemental) DumpSource(target string, imgSrc *v1.ImageSource) (info inte
 		err = e.config.ImageExtractor.ExtractImage(imgSrc.Value(), target, e.config.Platform.String())
 		if err != nil {
 			return nil, err
+		}
+	} else if imgSrc.IsOCITar() {
+		// Extract OCI image from tar file
+		e.config.Logger.Infof("Loading OCI image from tar file %s", imgSrc.Value())
+		
+		// Try to load the image from the tar file
+		// First attempt: Try to load without specifying a tag
+		img, err := tarball.ImageFromPath(imgSrc.Value(), nil)
+		
+		// Second attempt: If that fails, try with a specific tag
+		if err != nil {
+			e.config.Logger.Infof("Trying to load with explicit tag: %v", err)
+			tag, tagErr := name.NewTag("oci-image:latest")
+			if tagErr != nil {
+				e.config.Logger.Errorf("Failed to create tag reference: %v", tagErr)
+				return nil, fmt.Errorf("failed to create tag reference: %w", tagErr)
+			}
+			
+			img, err = tarball.ImageFromPath(imgSrc.Value(), &tag)
+			if err != nil {
+				// Third attempt: Try to extract the tar file directly
+				e.config.Logger.Infof("Trying to extract tar file directly: %v", err)
+				
+				// Create a temporary directory to extract the tar file
+				tmpDir, err := fsutils.TempDir(e.config.Fs, "", "ocitar-extract")
+				if err != nil {
+					e.config.Logger.Errorf("Failed to create temporary directory: %v", err)
+					return nil, fmt.Errorf("failed to create temporary directory: %w", err)
+				}
+				defer e.config.Fs.RemoveAll(tmpDir)
+				
+				// Extract the tar file to the temporary directory
+				e.config.Logger.Infof("Extracting tar file to temporary directory: %s", tmpDir)
+				cmd := fmt.Sprintf("tar -xf %s -C %s", imgSrc.Value(), tmpDir)
+				if _, err := e.config.Runner.Run(cmd); err != nil {
+					e.config.Logger.Errorf("Failed to extract tar file: %v", err)
+					return nil, fmt.Errorf("failed to extract tar file: %w", err)
+				}
+				
+				// Copy the extracted contents to the target
+				e.config.Logger.Infof("Copying extracted contents to target: %s", target)
+				excludes := []string{}
+				if err := utils.SyncData(e.config.Logger, e.config.Runner, e.config.Fs, tmpDir, target, excludes...); err != nil {
+					e.config.Logger.Errorf("Failed to copy extracted contents: %v", err)
+					return nil, fmt.Errorf("failed to copy extracted contents: %w", err)
+				}
+				
+				// Successfully extracted and copied the contents
+				return nil, nil
+			}
+		}
+		
+		if err != nil {
+			e.config.Logger.Errorf("Failed to load image from tar file: %v", err)
+			return nil, fmt.Errorf("failed to load image from tar file: %w", err)
+		}
+		
+		// Extract the image contents to the target
+		reader := mutate.Extract(img)
+		_, err = archive.Apply(context.Background(), target, reader)
+		if err != nil {
+			e.config.Logger.Errorf("Failed to extract image contents: %v", err)
+			return nil, fmt.Errorf("failed to extract image contents: %w", err)
 		}
 	} else if imgSrc.IsDir() {
 		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -420,7 +420,7 @@ func (e *Elemental) DumpSource(target string, imgSrc *v1.ImageSource) (info inte
 		// Extract OCI image from tar file
 		e.config.Logger.Infof("Loading OCI image from tar file %s", imgSrc.Value())
 
-		// Try to load the image from the tar file
+		// Accounting for different image save conventions between tools, load the image from the tar file
 		// First attempt: Try to load without specifying a tag
 		img, err := tarball.ImageFromPath(imgSrc.Value(), nil)
 
@@ -448,6 +448,7 @@ func (e *Elemental) DumpSource(target string, imgSrc *v1.ImageSource) (info inte
 
 				// Extract the tar file to the temporary directory
 				e.config.Logger.Infof("Extracting tar file to temporary directory: %s", tmpDir)
+				//TODO: update to use native golang tar
 				if out, err := e.config.Runner.Run("tar", "-xf", imgSrc.Value(), "-C", tmpDir); err != nil {
 					e.config.Logger.Errorf("Failed to extract tar file: %v\n%s", err, string(out))
 					return nil, fmt.Errorf("failed to extract tar file: %w", err)

--- a/pkg/types/v1/common.go
+++ b/pkg/types/v1/common.go
@@ -31,7 +31,7 @@ const (
 	oci     = "oci"
 	file    = "file"
 	dir     = "dir"
-	ocitar  = "ocitar"
+	ocifile = "ocifile"
 )
 
 // ImageSource represents the source from where an image is created for easy identification
@@ -56,8 +56,8 @@ func (i ImageSource) IsFile() bool {
 	return i.srcType == file
 }
 
-func (i ImageSource) IsOCITar() bool {
-	return i.srcType == ocitar
+func (i ImageSource) IsOCIFile() bool {
+	return i.srcType == ocifile
 }
 
 func (i ImageSource) IsEmpty() bool {
@@ -113,8 +113,8 @@ func (i *ImageSource) updateFromURI(uri string) error {
 	case file:
 		i.srcType = file
 		i.source = value
-	case ocitar:
-		i.srcType = ocitar
+	case ocifile:
+		i.srcType = ocifile
 		i.source = value
 	default:
 		return i.parseImageReference(uri)
@@ -156,6 +156,6 @@ func NewDirSrc(src string) *ImageSource {
 	return &ImageSource{source: src, srcType: dir}
 }
 
-func NewOCITarSrc(src string) *ImageSource {
-	return &ImageSource{source: src, srcType: ocitar}
+func NewOCIFileSrc(src string) *ImageSource {
+	return &ImageSource{source: src, srcType: ocifile}
 }

--- a/pkg/types/v1/common.go
+++ b/pkg/types/v1/common.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	docker = "docker"
-	oci    = "oci"
-	file   = "file"
-	dir    = "dir"
+	docker  = "docker"
+	oci     = "oci"
+	file    = "file"
+	dir     = "dir"
+	ocitar  = "ocitar"
 )
 
 // ImageSource represents the source from where an image is created for easy identification
@@ -53,6 +54,10 @@ func (i ImageSource) IsDir() bool {
 
 func (i ImageSource) IsFile() bool {
 	return i.srcType == file
+}
+
+func (i ImageSource) IsOCITar() bool {
+	return i.srcType == ocitar
 }
 
 func (i ImageSource) IsEmpty() bool {
@@ -108,6 +113,9 @@ func (i *ImageSource) updateFromURI(uri string) error {
 	case file:
 		i.srcType = file
 		i.source = value
+	case ocitar:
+		i.srcType = ocitar
+		i.source = value
 	default:
 		return i.parseImageReference(uri)
 	}
@@ -146,4 +154,8 @@ func NewFileSrc(src string) *ImageSource {
 
 func NewDirSrc(src string) *ImageSource {
 	return &ImageSource{source: src, srcType: dir}
+}
+
+func NewOCITarSrc(src string) *ImageSource {
+	return &ImageSource{source: src, srcType: ocitar}
 }

--- a/pkg/types/v1/common_test.go
+++ b/pkg/types/v1/common_test.go
@@ -18,6 +18,7 @@ package v1_test
 
 import (
 	"fmt"
+
 	"github.com/kairos-io/kairos-agent/v2/pkg/constants"
 	v1 "github.com/kairos-io/kairos-agent/v2/pkg/types/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -37,6 +38,8 @@ var _ = Describe("Types", Label("types", "common"), func() {
 			Expect(o.IsDir()).To(BeTrue())
 			o = v1.NewFileSrc("file")
 			Expect(o.IsFile()).To(BeTrue())
+			o = v1.NewOCIFileSrc("file")
+			Expect(o.IsOCIFile()).To(BeTrue())
 			o = v1.NewDockerSrc("image")
 			Expect(o.IsDocker()).To(BeTrue())
 			o = v1.NewEmptySrc()


### PR DESCRIPTION
For use cases without access to an OCI regsitry add support for an upgrade via an OCI image file.

`docker save -o os-upgrade-0.5.0.oci.tar ghcr.io/bdegeeter/edge-os:0.5.0`

Transfer `os-upgrade-0.5.0.oci.tar` to Kairos host.

`kairos-agent upgrade --source ocifile:/usr/local/os-upgrade-0.5.0.oci.tar`