### PR TITLE
Add grub edit var command

### DIFF
--- a/pkg/utils/grub.go
+++ b/pkg/utils/grub.go
@@ -474,6 +474,9 @@ func ReadPersistentVariables(grubEnvFile string, c *agentConfig.Config) (map[str
 		if strings.HasPrefix(a, "#") {
 			continue
 		}
+		if a == "" {
+			continue
+		}
 		splitted := strings.Split(a, "=")
 		if len(splitted) == 2 {
 			vars[splitted[0]] = splitted[1]


### PR DESCRIPTION
Adds a subcommand to list and read vars from a grubenv file from the agent, which removes any need for grub2-editenv to be in the lvie image

Fixes https://github.com/kairos-io/kairos/issues/154