### PR TITLE
fix: improve manual install argument handling

### DIFF
--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -381,6 +381,11 @@ func generateInstallConfForCLIArgs(sourceImageURL string) string {
 
 // generateInstallConfForManualCLIArgs creates a kairos configuration for flags passed via manual install
 func generateInstallConfForManualCLIArgs(device string, reboot, poweroff bool) string {
+	// if no options were passed, return empty string
+	if !reboot && !poweroff && device == "" {
+		return ""
+	}
+
 	cfg := "install:\n"
 	// Only add those options if they are set to true, otherwise it gets the default values from the config
 	if reboot {
@@ -391,10 +396,6 @@ func generateInstallConfForManualCLIArgs(device string, reboot, poweroff bool) s
 	}
 	if device != "" {
 		cfg += fmt.Sprintf("  device: %s\n", device)
-	}
-	// if no options were passed, return empty string
-	if !reboot && !poweroff && device == "" {
-		return ""
 	}
 	return cfg
 }


### PR DESCRIPTION
Refactor the configuration generation for manual install CLI arguments to only include options that are explicitly set to true. This prevents unnecessary defaults from being included and returns an empty string if no options are provided.