### PR TITLE
fix: skip processing of host and runtime directories

### DIFF
--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -889,7 +889,7 @@ func GetSourceSize(config *Config, source *v1.ImageSource) (int64, error) {
 		err = fsutils.WalkDirFs(config.Fs, source.Value(), func(path string, d fs.DirEntry, err error) error {
 			// If its empty we are just not setting it, so probably out of the k8s upgrade path
 			if hostDir != "" && strings.HasPrefix(path, hostDir) {
-				config.Logger.Logger.Debug().Str("path", path).Str("hostDir", hostDir).Msg("Skipping file as it is a host directory")
+				config.Logger.Logger.Debug().Str("path", path).Str("hostDir", hostDir).Msg("Skipping dir as it is a host directory")
 				return fs.SkipDir
 			} else if underKubernetes && (strings.HasPrefix(path, "/proc") || strings.HasPrefix(path, "/dev") || strings.HasPrefix(path, "/run")) {
 				// If under kubernetes, the upgrade will check the size of / which includes the host dir mounted under /host


### PR DESCRIPTION
Prevent processing of host directories and specific runtime directories (/proc, /dev, /run) during file operations to ensure compatibility with Kubernetes upgrades and installations.

Fixes https://github.com/kairos-io/kairos/issues/3651#issuecomment-3278909263