### PR TITLE
Enhance --select to support partial matches for boot entries

### DIFF
--- a/pkg/action/bootentries.go
+++ b/pkg/action/bootentries.go
@@ -156,7 +156,26 @@ func selectBootEntrySystemd(cfg *sdkConfig.Config, entry string) error {
 	err = entryInList(cfg, entry, entries)
 	// we also accept "active" as a selection so we can migrate eventually from cos
 	if err != nil && !strings.HasPrefix(entry, "active") {
-		return err
+		// Exact match failed against the (possibly simplified) entries list.
+		// Try a partial/substring match against the original entry names so that
+		// callers can use short names like "registration" to select an entry such
+		// as "recovery install-mode_stylus.registration".
+		var partialMatch string
+		for _, e := range originalEntries {
+			if strings.Contains(e, entry) {
+				if partialMatch != "" {
+					cfg.Logger.Errorf("entry %s is ambiguous, matches both %s and %s", entry, partialMatch, e)
+					return fmt.Errorf("entry %s is ambiguous", entry)
+				}
+				partialMatch = e
+			}
+		}
+		if partialMatch == "" {
+			return err
+		}
+		cfg.Logger.Debugf("entry %s matched %s via partial match", entry, partialMatch)
+		entry = partialMatch
+		err = nil
 	}
 
 	// Check if efi is RW or RO

--- a/pkg/action/bootentries_test.go
+++ b/pkg/action/bootentries_test.go
@@ -235,6 +235,47 @@ var _ = Describe("Bootentries tests", Label("bootentry"), func() {
 				Expect(ReadOneShotEfiVar(config)).To(Equal("active_install-mode_awesomeos.conf"))
 			})
 
+			It("selects the boot entry via partial match when a unique substring match exists", func() {
+				// Scenario from https://github.com/kairos-io/kairos/issues/4038
+				// kairos-init >= 0.8.5 names entries like recovery_install-mode_stylus.registration.conf
+				// but cloud-init scripts call --select registration (the old short form).
+				// When the partial search term uniquely matches one entry it should succeed.
+				err := fs.WriteFile("/efi/loader/entries/active.conf", []byte("title kairos\nefi /EFI/kairos/active.efi\n"), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+				err = fs.WriteFile("/efi/loader/entries/passive.conf", []byte("title kairos (fallback)\nefi /EFI/kairos/passive.efi\n"), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+				err = fs.WriteFile("/efi/loader/entries/recovery_install-mode_stylus.registration.conf", []byte("title kairos recovery\nefi /EFI/kairos/recovery_install-mode_stylus.registration.efi\n"), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+				err = fs.WriteFile("/efi/loader/entries/statereset.conf", []byte("title kairos statereset\nefi /EFI/kairos/statereset.efi\n"), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+				err = fs.WriteFile("/efi/loader/loader.conf", []byte(""), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+
+				// "registration" is a substring of "recovery install-mode_stylus.registration" only
+				err = SelectBootEntry(config, "registration")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(memLog.String()).To(ContainSubstring("matched"))
+				Expect(ReadOneShotEfiVar(config)).To(Equal("recovery_install-mode_stylus.registration.conf"))
+			})
+
+			It("returns an ambiguous error when a partial match hits multiple entries", func() {
+				err := fs.WriteFile("/efi/loader/entries/active.conf", []byte("title kairos\nefi /EFI/kairos/active.efi\n"), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+				err = fs.WriteFile("/efi/loader/entries/passive.conf", []byte("title kairos (fallback)\nefi /EFI/kairos/passive.efi\n"), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+				err = fs.WriteFile("/efi/loader/entries/recovery_install-mode_stylus.registration.conf", []byte("title kairos recovery\nefi /EFI/kairos/recovery_install-mode_stylus.registration.efi\n"), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+				err = fs.WriteFile("/efi/loader/entries/statereset_install-mode_stylus.registration.conf", []byte("title kairos statereset\nefi /EFI/kairos/statereset_install-mode_stylus.registration.efi\n"), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+				err = fs.WriteFile("/efi/loader/loader.conf", []byte(""), os.ModePerm)
+				Expect(err).ToNot(HaveOccurred())
+
+				// "registration" is a substring of BOTH recovery and statereset entries → ambiguous
+				err = SelectBootEntry(config, "registration")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ambiguous"))
+			})
+
 			It("selects the boot entry in a extra-cmdline installation", func() {
 				err := fs.WriteFile("/efi/loader/entries/active.conf", []byte("title Kairos\nefi /EFI/kairos/active.efi\n"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION

When kairos-init >= 0.8.5 generates UKI boot entries with extended names (e.g. recovery_install-mode_stylus.registration.conf), the short form used by cloud-init scripts (--select registration) fails with "entry does not exist" because only exact matches were attempted.

After the exact-match check fails, fall back to substring matching against the original (pre-simplified) entry names. If exactly one entry matches, resolve and use it. If multiple entries match, return a clear "ambiguous" error instead of the misleading "does not exist".

Fixes: https://github.com/kairos-io/kairos/issues/4038