### PR TITLE
fix(phonehome): address PR review feedback and gosec findings

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -64,8 +64,8 @@ func Run(opts ...Option) error {
 	}
 	_, err = bus.Manager.Publish(events.EventBootstrap, events.BootstrapPayload{APIAddress: o.APIAddress, Config: configStr, Logfile: fileName})
 
-	// If daedalus config is present, install and start the phone-home service
-	enablePhoneHomeIfConfigured(o.Dir)
+	// If phonehome config is present in cloud-config, install+start the service.
+	enablePhoneHomeIfConfigured(c)
 
 	if o.Restart && err != nil {
 		fmt.Println("Warning: Agent failed, restarting: ", err.Error())

--- a/internal/agent/phonehome_service.go
+++ b/internal/agent/phonehome_service.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/kairos-io/kairos-agent/v2/internal/phonehome"
+	sdkConfig "github.com/kairos-io/kairos-sdk/types/config"
 )
 
 const phoneHomeServiceName = "kairos-agent-phonehome"
 const phoneHomeServicePath = "/etc/systemd/system/kairos-agent-phonehome.service"
 const phoneHomeServiceContent = `[Unit]
-Description=Kairos Agent Phone Home (Daedalus)
+Description=Kairos Agent Phone Home
 After=network-online.target
 Wants=network-online.target
 
@@ -27,69 +27,36 @@ RestartSec=10
 WantedBy=multi-user.target
 `
 
-// enablePhoneHomeIfConfigured checks if daedalus configuration exists in the
-// cloud-config directories and, if so, installs and starts the phone-home
-// systemd service. This is called during `kairos-agent start`.
-func enablePhoneHomeIfConfigured(dirs []string) {
-	if !hasPhonehomeConfig(dirs) {
+// enablePhoneHomeIfConfigured installs and starts the phone-home systemd service
+// when a `phonehome:` section with a url is present in the merged cloud-config.
+// The config is parsed by phonehome.LoadFromCollector so it uses the same
+// Collector output as the rest of the kairos-agent (no separate file walk).
+func enablePhoneHomeIfConfigured(c *sdkConfig.Config) {
+	cfg, ok, err := phonehome.LoadFromCollector(c)
+	if err != nil {
+		fmt.Printf("Warning: could not parse phonehome config: %v\n", err)
+		return
+	}
+	if !ok || cfg.URL == "" {
 		return
 	}
 
-	fmt.Println("Daedalus configuration detected, enabling phone-home service")
+	fmt.Println("Phone-home configuration detected, enabling phone-home service")
 
-	// Write the systemd service file
-	if err := os.WriteFile(phoneHomeServicePath, []byte(phoneHomeServiceContent), 0644); err != nil {
+	if err := os.WriteFile(phoneHomeServicePath, []byte(phoneHomeServiceContent), 0600); err != nil {
 		fmt.Printf("Warning: failed to write phone-home service: %v\n", err)
 		return
 	}
 
-	// Reload systemd and enable + start the service
-	cmds := [][]string{
+	for _, args := range [][]string{
 		{"systemctl", "daemon-reload"},
 		{"systemctl", "enable", phoneHomeServiceName},
 		{"systemctl", "start", phoneHomeServiceName},
-	}
-
-	for _, args := range cmds {
-		cmd := exec.Command(args[0], args[1:]...)
+	} {
+		// args is a literal slice defined just above — no user input reaches exec.Command.
+		cmd := exec.Command(args[0], args[1:]...) //nosec G204 -- fixed command and arguments
 		if out, err := cmd.CombinedOutput(); err != nil {
 			fmt.Printf("Warning: %s failed: %v (%s)\n", strings.Join(args, " "), err, string(out))
 		}
 	}
-}
-
-// hasPhonehomeConfig checks if any cloud-config file in the given directories
-// contains a `phonehome:` section with a `url` field.
-func hasPhonehomeConfig(dirs []string) bool {
-	for _, dir := range dirs {
-		found := false
-		// Walk recursively — Kairos stores datasource cloud-config in
-		// subdirectories like /oem/95_userdata/userdata.yaml
-		_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-			if err != nil || info.IsDir() {
-				return nil
-			}
-			if !strings.HasSuffix(info.Name(), ".yaml") && !strings.HasSuffix(info.Name(), ".yml") {
-				return nil
-			}
-			data, readErr := os.ReadFile(path)
-			if readErr != nil {
-				return nil
-			}
-			var cc struct {
-				Phonehome struct {
-					URL string `yaml:"url"`
-				} `yaml:"phonehome"`
-			}
-			if yaml.Unmarshal(data, &cc) == nil && cc.Phonehome.URL != "" {
-				found = true
-				return filepath.SkipAll
-			}
-			return nil
-		})
-		if found {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/phonehome/client.go
+++ b/internal/phonehome/client.go
@@ -20,7 +20,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// CommandHandler is called when a command is received from daedalus.
+// CommandHandler is called when a command is received from the management server.
 // It should execute the command and return a result string and any error.
 type CommandHandler func(cmd CommandData) (result string, err error)
 
@@ -47,7 +47,7 @@ func WithLogger(l *log.Logger) ClientOption {
 	return func(c *Client) { c.logger = l }
 }
 
-// Client manages the connection to a daedalus server.
+// Client manages the connection to a phone-home management server.
 type Client struct {
 	cfg         *Config
 	credentials *Credentials
@@ -97,7 +97,7 @@ func NewClient(cfg *Config, opts ...ClientOption) *Client {
 	return c
 }
 
-// Register contacts daedalus to register this node. Stores credentials locally.
+// Register contacts the server to register this node. Stores credentials locally.
 // If credentials already exist on disk, they are loaded and registration is skipped.
 func (c *Client) Register(ctx context.Context) error {
 	// Try loading existing credentials
@@ -156,7 +156,7 @@ func (c *Client) Register(ctx context.Context) error {
 	return nil
 }
 
-// Connect establishes a WebSocket connection to daedalus and handles messages.
+// Connect establishes a WebSocket connection to the server and handles messages.
 // It blocks until the connection is closed or the context is cancelled.
 func (c *Client) Connect(ctx context.Context) error {
 	if c.credentials == nil {

--- a/internal/phonehome/client.go
+++ b/internal/phonehome/client.go
@@ -178,7 +178,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	c.mu.Unlock()
 
 	defer func() {
-		conn.Close()
+		_ = conn.Close()
 		c.mu.Lock()
 		c.conn = nil
 		c.mu.Unlock()
@@ -201,7 +201,7 @@ func (c *Client) Connect(ctx context.Context) error {
 		_ = conn.WriteMessage(websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 		c.mu.Unlock()
-		conn.Close()
+		_ = conn.Close()
 	}()
 
 	// Start heartbeat writer
@@ -298,8 +298,11 @@ func (c *Client) heartbeatLoop(ctx context.Context, conn *websocket.Conn) {
 	ticker := time.NewTicker(c.cfg.HeartbeatInterval)
 	defer ticker.Stop()
 
-	// Send initial heartbeat immediately
-	c.sendHeartbeat(conn)
+	// Send initial heartbeat immediately. If it fails the ticker-driven loop
+	// below will surface the next write error, so log-and-continue is enough here.
+	if err := c.sendHeartbeat(conn); err != nil {
+		c.logger.Printf("initial heartbeat error: %v", err)
+	}
 
 	for {
 		select {

--- a/internal/phonehome/client_test.go
+++ b/internal/phonehome/client_test.go
@@ -24,6 +24,7 @@ type mockServer struct {
 	mu       sync.Mutex
 	regCalls int
 	lastReg  phonehome.RegisterRequest
+	wsToken  string
 	// WS tracking
 	wsConnected    chan struct{}
 	heartbeats     []phonehome.HeartbeatData
@@ -31,9 +32,22 @@ type mockServer struct {
 	commandsToSend []phonehome.CommandData
 }
 
+func (ms *mockServer) setWSToken(t string) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	ms.wsToken = t
+}
+
+func (ms *mockServer) getWSToken() string {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	return ms.wsToken
+}
+
 func newMockServer(validToken string) *mockServer {
 	ms := &mockServer{
 		wsConnected: make(chan struct{}, 1),
+		wsToken:     "test-api-key",
 	}
 
 	mux := http.NewServeMux()
@@ -69,7 +83,7 @@ func newMockServer(validToken string) *mockServer {
 
 	mux.HandleFunc("/api/v1/ws", func(w http.ResponseWriter, r *http.Request) {
 		token := r.URL.Query().Get("token")
-		if token != "test-api-key" {
+		if token != ms.getWSToken() {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -257,6 +271,25 @@ var _ = Describe("PhoneHome Client", func() {
 			ms.mu.Lock()
 			defer ms.mu.Unlock()
 			Expect(len(ms.heartbeats)).To(BeNumerically(">=", 2))
+		})
+
+		It("should fail when the stored API key is rejected by the server", func() {
+			// Register with a valid registration token so credentials are stored,
+			// then make the server reject the resulting API key on the WS handshake.
+			// This covers the case where the registration token is correct but the
+			// node's API key is invalid/revoked at connection time.
+			client := newTestClient("test-token")
+			err := client.Register(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+
+			ms.setWSToken("some-other-key")
+
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+
+			err = client.Connect(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("websocket"))
 		})
 
 		It("should receive and handle command messages", func() {

--- a/internal/phonehome/config.go
+++ b/internal/phonehome/config.go
@@ -2,14 +2,20 @@ package phonehome
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
+
+	sdkConfig "github.com/kairos-io/kairos-sdk/types/config"
+	"gopkg.in/yaml.v3"
 )
 
 const (
 	DefaultHeartbeatInterval = 30 * time.Second
 	DefaultReconnectBackoff  = 5 * time.Second
 	MaxReconnectBackoff      = 60 * time.Second
-	DefaultCredentialsPath   = "/usr/local/.kairos/daedalus-credentials.yaml"
+	// DefaultCredentialsPath is the on-disk location of the node's saved
+	// credentials. It is a filesystem path, not an embedded secret.
+	DefaultCredentialsPath = "/usr/local/.kairos/daedalus-credentials.yaml" //nosec G101 -- path, not credential
 )
 
 // Config holds the phone-home configuration, typically read from cloud-config.
@@ -20,12 +26,71 @@ type Config struct {
 	Labels            map[string]string `yaml:"labels"`
 	HeartbeatInterval time.Duration     `yaml:"heartbeat_interval"`
 	ReconnectBackoff  time.Duration     `yaml:"reconnect_backoff"`
+	// AllowedCommands is the list of remote commands the node will execute.
+	// When nil, defaults to DefaultAllowedCommands (upgrade/reboot only).
+	// Destructive commands (exec, reset, apply-cloud-config) must be opted-in
+	// explicitly because a DNS hijack / rogue server can reach this endpoint.
+	AllowedCommands []string `yaml:"allowed_commands"`
+}
+
+// DefaultAllowedCommands is the conservative set of commands a phone-home node
+// will execute when the user has not specified allowed_commands in cloud-config.
+// It intentionally excludes exec, reset and apply-cloud-config.
+var DefaultAllowedCommands = []string{"upgrade", "upgrade-recovery", "reboot"}
+
+// IsAllowed reports whether the given command name is permitted by this config.
+// Matching is exact. A nil AllowedCommands falls back to DefaultAllowedCommands;
+// an explicitly empty slice means "deny everything".
+func (c *Config) IsAllowed(cmd string) bool {
+	list := c.AllowedCommands
+	if list == nil {
+		list = DefaultAllowedCommands
+	}
+	for _, a := range list {
+		if a == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+// cloudConfigEnvelope is the shape of the phonehome: section inside a kairos
+// cloud-config. We parse the merged Collector output (not individual files) so
+// all the usual Kairos config sources and precedence rules apply.
+type cloudConfigEnvelope struct {
+	Phonehome Config `yaml:"phonehome"`
+}
+
+// LoadFromCollector extracts the phonehome configuration from an already-scanned
+// Kairos config. It returns (cfg, true, nil) if a phonehome.url is present,
+// (nil, false, nil) if the section is missing or empty, and (nil, false, err)
+// if the merged config could not be re-serialized or parsed.
+func LoadFromCollector(c *sdkConfig.Config) (*Config, bool, error) {
+	if c == nil {
+		return nil, false, nil
+	}
+	raw, err := c.Collector.String()
+	if err != nil {
+		return nil, false, fmt.Errorf("rendering merged cloud-config: %w", err)
+	}
+	var env cloudConfigEnvelope
+	if err := yaml.Unmarshal([]byte(raw), &env); err != nil {
+		return nil, false, fmt.Errorf("parsing phonehome section: %w", err)
+	}
+	if env.Phonehome.URL == "" {
+		return nil, false, nil
+	}
+	cfg := env.Phonehome
+	return &cfg, true, nil
 }
 
 // Credentials stores the node's registration result.
 type Credentials struct {
 	NodeID string `yaml:"node_id" json:"id"`
-	APIKey string `yaml:"api_key" json:"apiKey"`
+	// APIKey is the node's bearer token returned by the server after
+	// registration. The name matches the secret-pattern detector by design —
+	// this field *is* the session credential — but it is not a hardcoded value.
+	APIKey string `yaml:"api_key" json:"apiKey"` //nosec G101 -- legitimate credential carrier, populated at runtime
 }
 
 // RegisterRequest is the body sent to POST /api/v1/nodes/register.

--- a/internal/phonehome/config.go
+++ b/internal/phonehome/config.go
@@ -15,7 +15,7 @@ const (
 	MaxReconnectBackoff      = 60 * time.Second
 	// DefaultCredentialsPath is the on-disk location of the node's saved
 	// credentials. It is a filesystem path, not an embedded secret.
-	DefaultCredentialsPath = "/usr/local/.kairos/daedalus-credentials.yaml" //nosec G101 -- path, not credential
+	DefaultCredentialsPath = "/usr/local/.kairos/phonehome-credentials.yaml" //nosec G101 -- path, not credential
 )
 
 // Config holds the phone-home configuration, typically read from cloud-config.
@@ -116,7 +116,7 @@ type HeartbeatData struct {
 	Labels       map[string]string `json:"labels,omitempty"`
 }
 
-// CommandData is received from daedalus.
+// CommandData is received from the management server.
 type CommandData struct {
 	ID      string            `json:"id"`
 	Command string            `json:"command"`

--- a/internal/phonehome/config_test.go
+++ b/internal/phonehome/config_test.go
@@ -2,9 +2,85 @@ package phonehome_test
 
 import (
 	"github.com/kairos-io/kairos-agent/v2/internal/phonehome"
+	"github.com/kairos-io/kairos-sdk/collector"
+	sdkConfig "github.com/kairos-io/kairos-sdk/types/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// newCollectorConfig builds an sdkConfig.Config whose Collector renders
+// to the given phonehome-scoped values. This is exactly the shape produced
+// by a real `config.Scan` on cloud-config files — the helper just skips
+// the file I/O so LoadFromCollector can be tested in isolation.
+func newCollectorConfig(phonehome map[string]interface{}) *sdkConfig.Config {
+	values := collector.ConfigValues{}
+	if phonehome != nil {
+		values["phonehome"] = phonehome
+	}
+	return &sdkConfig.Config{
+		Collector: collector.Config{Values: values},
+	}
+}
+
+var _ = Describe("LoadFromCollector", func() {
+	It("extracts a phonehome section from a merged cloud-config", func() {
+		c := newCollectorConfig(map[string]interface{}{
+			"url":                "https://example.invalid",
+			"registration_token": "reg-123",
+			"group":              "edge",
+			"labels":             map[string]interface{}{"env": "prod"},
+			"allowed_commands":   []interface{}{"exec", "reboot"},
+		})
+
+		cfg, ok, err := phonehome.LoadFromCollector(c)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+		Expect(cfg).ToNot(BeNil())
+		Expect(cfg.URL).To(Equal("https://example.invalid"))
+		Expect(cfg.RegistrationToken).To(Equal("reg-123"))
+		Expect(cfg.Group).To(Equal("edge"))
+		Expect(cfg.Labels).To(HaveKeyWithValue("env", "prod"))
+		Expect(cfg.AllowedCommands).To(ConsistOf("exec", "reboot"))
+	})
+
+	It("returns ok=false when the phonehome section is absent", func() {
+		c := newCollectorConfig(nil)
+		cfg, ok, err := phonehome.LoadFromCollector(c)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+		Expect(cfg).To(BeNil())
+	})
+
+	It("returns ok=false when phonehome.url is empty", func() {
+		c := newCollectorConfig(map[string]interface{}{
+			"group": "edge",
+		})
+		cfg, ok, err := phonehome.LoadFromCollector(c)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+		Expect(cfg).To(BeNil())
+	})
+
+	It("returns ok=false on a nil sdkConfig.Config pointer", func() {
+		cfg, ok, err := phonehome.LoadFromCollector(nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+		Expect(cfg).To(BeNil())
+	})
+
+	It("round-trips the full Config back through IsAllowed", func() {
+		c := newCollectorConfig(map[string]interface{}{
+			"url":              "https://example.invalid",
+			"allowed_commands": []interface{}{"exec"},
+		})
+		cfg, ok, err := phonehome.LoadFromCollector(c)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+		// The policy parsed out of the Collector must drive IsAllowed correctly.
+		Expect(cfg.IsAllowed("exec")).To(BeTrue())
+		Expect(cfg.IsAllowed("reboot")).To(BeFalse())
+	})
+})
 
 var _ = Describe("Config.IsAllowed", func() {
 	It("allows the default safe set when AllowedCommands is nil", func() {

--- a/internal/phonehome/config_test.go
+++ b/internal/phonehome/config_test.go
@@ -1,0 +1,69 @@
+package phonehome_test
+
+import (
+	"github.com/kairos-io/kairos-agent/v2/internal/phonehome"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Config.IsAllowed", func() {
+	It("allows the default safe set when AllowedCommands is nil", func() {
+		cfg := &phonehome.Config{}
+		Expect(cfg.IsAllowed("upgrade")).To(BeTrue())
+		Expect(cfg.IsAllowed("upgrade-recovery")).To(BeTrue())
+		Expect(cfg.IsAllowed("reboot")).To(BeTrue())
+	})
+
+	It("denies destructive commands by default", func() {
+		cfg := &phonehome.Config{}
+		Expect(cfg.IsAllowed("exec")).To(BeFalse())
+		Expect(cfg.IsAllowed("reset")).To(BeFalse())
+		Expect(cfg.IsAllowed("apply-cloud-config")).To(BeFalse())
+	})
+
+	It("honors an explicit AllowedCommands allowlist", func() {
+		cfg := &phonehome.Config{AllowedCommands: []string{"exec"}}
+		Expect(cfg.IsAllowed("exec")).To(BeTrue())
+		// Explicit list replaces defaults — reboot is no longer allowed.
+		Expect(cfg.IsAllowed("reboot")).To(BeFalse())
+	})
+
+	It("treats an empty (non-nil) slice as deny-all", func() {
+		cfg := &phonehome.Config{AllowedCommands: []string{}}
+		Expect(cfg.IsAllowed("upgrade")).To(BeFalse())
+		Expect(cfg.IsAllowed("reboot")).To(BeFalse())
+	})
+})
+
+var _ = Describe("DefaultCommandHandler policy gating", func() {
+	It("rejects commands that are not in the allowlist", func() {
+		cfg := &phonehome.Config{} // defaults — exec not allowed
+		handler := phonehome.DefaultCommandHandler("http://example", func() string { return "" }, cfg.IsAllowed)
+
+		out, err := handler(phonehome.CommandData{
+			ID:      "c1",
+			Command: "exec",
+			Args:    map[string]string{"command": "echo hi"},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not permitted"))
+		Expect(out).To(BeEmpty())
+	})
+
+	It("rejects unknown commands even when listed in defaults", func() {
+		cfg := &phonehome.Config{}
+		handler := phonehome.DefaultCommandHandler("http://example", func() string { return "" }, cfg.IsAllowed)
+
+		_, err := handler(phonehome.CommandData{ID: "c2", Command: "totally-made-up"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not permitted"))
+	})
+
+	It("denies everything when isAllowed is nil (fail-closed)", func() {
+		handler := phonehome.DefaultCommandHandler("http://example", func() string { return "" }, nil)
+
+		_, err := handler(phonehome.CommandData{ID: "c3", Command: "upgrade"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not permitted"))
+	})
+})

--- a/internal/phonehome/handlers.go
+++ b/internal/phonehome/handlers.go
@@ -13,8 +13,19 @@ import (
 
 // DefaultCommandHandler returns a CommandHandler that handles all daedalus commands.
 // The daedalusURL and apiKey are needed to download artifact images for upgrades.
-func DefaultCommandHandler(daedalusURL string, apiKey func() string) CommandHandler {
+//
+// isAllowed gates execution: a command is only dispatched if isAllowed(cmd.Command)
+// returns true. This exists because a rogue/DNS-hijacked server could otherwise
+// drive arbitrary `exec`, `reset`, or `apply-cloud-config` on the node. Destructive
+// commands are opt-in per Config.AllowedCommands. If isAllowed is nil, every command
+// is denied (safer default than allowing everything when the caller forgets to wire
+// the policy through).
+func DefaultCommandHandler(daedalusURL string, apiKey func() string, isAllowed func(string) bool) CommandHandler {
 	return func(cmd CommandData) (string, error) {
+		if isAllowed == nil || !isAllowed(cmd.Command) {
+			return "", fmt.Errorf("command %q is not permitted by the phonehome policy; add it to phonehome.allowed_commands in cloud-config to opt in", cmd.Command)
+		}
+
 		ctx := context.Background()
 
 		switch cmd.Command {
@@ -23,7 +34,8 @@ func DefaultCommandHandler(daedalusURL string, apiKey func() string) CommandHand
 			if !ok {
 				return "", fmt.Errorf("exec command requires 'command' arg")
 			}
-			out, err := exec.CommandContext(ctx, "sh", "-c", cmdStr).CombinedOutput()
+			// Arbitrary shell is opt-in via phonehome.allowed_commands (see gate above).
+			out, err := exec.CommandContext(ctx, "sh", "-c", cmdStr).CombinedOutput() //nosec G204 -- gated by Config.AllowedCommands policy
 			return string(out), err
 
 		case "upgrade", "upgrade-recovery":
@@ -54,32 +66,45 @@ func handleUpgrade(ctx context.Context, cmd CommandData, daedalusURL string, api
 	// If source is "artifact:<id>", download the container image tar from daedalus
 	if strings.HasPrefix(source, "artifact:") {
 		artifactID := strings.TrimPrefix(source, "artifact:")
+		// Artifact IDs come from the management server — constrain to a safe
+		// character set so they can't traverse out of /tmp or poison the URL path.
+		if !isSafeArtifactID(artifactID) {
+			return "", fmt.Errorf("invalid artifact id %q", artifactID)
+		}
 		tarPath := fmt.Sprintf("/tmp/daedalus-upgrade-%s.tar", artifactID)
 
 		imageURL := fmt.Sprintf("%s/api/v1/artifacts/%s/image?token=%s",
 			strings.TrimRight(daedalusURL, "/"), artifactID, apiKey)
 
-		resp, err := http.Get(imageURL)
+		// daedalusURL is operator-configured via cloud-config, not user input.
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil) //nosec G107 -- URL derived from operator cloud-config
+		if err != nil {
+			return "", fmt.Errorf("building artifact image request: %w", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return "", fmt.Errorf("downloading artifact image: %w", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode != http.StatusOK {
 			return "", fmt.Errorf("downloading artifact image: HTTP %d", resp.StatusCode)
 		}
 
-		f, err := os.Create(tarPath)
+		f, err := os.Create(tarPath) //nosec G304 -- tarPath is built from a validated artifactID under /tmp
 		if err != nil {
 			return "", fmt.Errorf("creating tar file: %w", err)
 		}
 		if _, err = io.Copy(f, resp.Body); err != nil {
-			f.Close()
-			os.Remove(tarPath)
+			_ = f.Close()
+			_ = os.Remove(tarPath)
 			return "", fmt.Errorf("writing tar file: %w", err)
 		}
-		f.Close()
-		defer os.Remove(tarPath)
+		if err := f.Close(); err != nil {
+			_ = os.Remove(tarPath)
+			return "", fmt.Errorf("closing tar file: %w", err)
+		}
+		defer func() { _ = os.Remove(tarPath) }()
 
 		source = "ocifile:" + tarPath
 	} else if !strings.Contains(source, ":") {
@@ -93,7 +118,7 @@ func handleUpgrade(ctx context.Context, cmd CommandData, daedalusURL string, api
 
 	// Use background context — upgrade must NOT be killed if WS disconnects
 	fmt.Printf("[phonehome] Running: kairos-agent %s\n", strings.Join(args, " "))
-	out, err := exec.Command("kairos-agent", args...).CombinedOutput()
+	out, err := exec.Command("kairos-agent", args...).CombinedOutput() //nosec G204 -- args is a fixed set built from validated CommandData fields
 	fmt.Printf("[phonehome] Exit: err=%v output=%s\n", err, string(out))
 	if err != nil {
 		return string(out), err
@@ -119,7 +144,7 @@ func handleReset(cmd CommandData) (string, error) {
 	}
 
 	fmt.Printf("[phonehome] Running: kairos-agent %s\n", strings.Join(args, " "))
-	out, err := exec.Command("kairos-agent", args...).CombinedOutput()
+	out, err := exec.Command("kairos-agent", args...).CombinedOutput() //nosec G204 -- args is a fixed set built from validated CommandData fields
 	fmt.Printf("[phonehome] Exit: err=%v output=%s\n", err, string(out))
 	if err != nil {
 		return string(out), err
@@ -164,19 +189,45 @@ func writeOEMCloudConfig(content string) error {
 		content = "#cloud-config\n" + content
 	}
 
-	// Ensure /oem is mounted (it may have been unmounted during reset)
-	os.MkdirAll("/oem", 0755)
-	// Try to mount — ignore error if already mounted
-	exec.Command("mount", "-L", "COS_OEM", "/oem").Run()
+	// Ensure /oem is mounted (it may have been unmounted during reset).
+	// MkdirAll is best-effort: if /oem already exists we proceed; any other
+	// failure will surface from the mount attempt or WriteFile below.
+	if err := os.MkdirAll("/oem", 0750); err != nil {
+		fmt.Printf("[phonehome] mkdir /oem: %v\n", err)
+	}
+	// Best-effort mount — error is expected and ignored when /oem is already mounted.
+	_ = exec.Command("mount", "-L", "COS_OEM", "/oem").Run() //nosec G204 -- fixed label, called on local mountpoint
 
-	return os.WriteFile("/oem/99_daedalus_remote.yaml", []byte(content), 0644)
+	return os.WriteFile("/oem/99_daedalus_remote.yaml", []byte(content), 0600)
 }
 
 // scheduleReboot syncs filesystems and reboots after a short delay.
 func scheduleReboot() {
 	go func() {
-		exec.Command("sync").Run()
+		// Best-effort flush then reboot — we're going down either way.
+		_ = exec.Command("sync").Run()   //nosec G204 -- fixed command
 		time.Sleep(10 * time.Second)
-		exec.Command("reboot").Run()
+		_ = exec.Command("reboot").Run() //nosec G204 -- fixed command
 	}()
+}
+
+// isSafeArtifactID whitelists characters acceptable inside an artifact
+// identifier: alphanumeric, dash, underscore, dot. This prevents the ID from
+// containing path separators or shell metacharacters when it is interpolated
+// into /tmp paths and request URLs.
+func isSafeArtifactID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/internal/phonehome/handlers.go
+++ b/internal/phonehome/handlers.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
-// DefaultCommandHandler returns a CommandHandler that handles all daedalus commands.
-// The daedalusURL and apiKey are needed to download artifact images for upgrades.
+// DefaultCommandHandler returns a CommandHandler that handles all phone-home commands.
+// The serverURL and apiKey are needed to download artifact images for upgrades.
 //
 // isAllowed gates execution: a command is only dispatched if isAllowed(cmd.Command)
 // returns true. This exists because a rogue/DNS-hijacked server could otherwise
@@ -20,7 +20,7 @@ import (
 // commands are opt-in per Config.AllowedCommands. If isAllowed is nil, every command
 // is denied (safer default than allowing everything when the caller forgets to wire
 // the policy through).
-func DefaultCommandHandler(daedalusURL string, apiKey func() string, isAllowed func(string) bool) CommandHandler {
+func DefaultCommandHandler(serverURL string, apiKey func() string, isAllowed func(string) bool) CommandHandler {
 	return func(cmd CommandData) (string, error) {
 		if isAllowed == nil || !isAllowed(cmd.Command) {
 			return "", fmt.Errorf("command %q is not permitted by the phonehome policy; add it to phonehome.allowed_commands in cloud-config to opt in", cmd.Command)
@@ -39,7 +39,7 @@ func DefaultCommandHandler(daedalusURL string, apiKey func() string, isAllowed f
 			return string(out), err
 
 		case "upgrade", "upgrade-recovery":
-			return handleUpgrade(ctx, cmd, daedalusURL, apiKey())
+			return handleUpgrade(ctx, cmd, serverURL, apiKey())
 
 		case "reset":
 			return handleReset(cmd)
@@ -57,13 +57,13 @@ func DefaultCommandHandler(daedalusURL string, apiKey func() string, isAllowed f
 }
 
 // handleUpgrade downloads the image (if artifact-based) and runs kairos-agent upgrade.
-func handleUpgrade(ctx context.Context, cmd CommandData, daedalusURL string, apiKey string) (string, error) {
+func handleUpgrade(ctx context.Context, cmd CommandData, serverURL string, apiKey string) (string, error) {
 	source := cmd.Args["source"]
 	if source == "" {
 		return "", fmt.Errorf("upgrade requires 'source' arg")
 	}
 
-	// If source is "artifact:<id>", download the container image tar from daedalus
+	// If source is "artifact:<id>", download the container image tar from the server.
 	if strings.HasPrefix(source, "artifact:") {
 		artifactID := strings.TrimPrefix(source, "artifact:")
 		// Artifact IDs come from the management server — constrain to a safe
@@ -71,12 +71,12 @@ func handleUpgrade(ctx context.Context, cmd CommandData, daedalusURL string, api
 		if !isSafeArtifactID(artifactID) {
 			return "", fmt.Errorf("invalid artifact id %q", artifactID)
 		}
-		tarPath := fmt.Sprintf("/tmp/daedalus-upgrade-%s.tar", artifactID)
+		tarPath := fmt.Sprintf("/tmp/phonehome-upgrade-%s.tar", artifactID)
 
 		imageURL := fmt.Sprintf("%s/api/v1/artifacts/%s/image?token=%s",
-			strings.TrimRight(daedalusURL, "/"), artifactID, apiKey)
+			strings.TrimRight(serverURL, "/"), artifactID, apiKey)
 
-		// daedalusURL is operator-configured via cloud-config, not user input.
+		// serverURL is operator-configured via cloud-config, not user input.
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil) //nosec G107 -- URL derived from operator cloud-config
 		if err != nil {
 			return "", fmt.Errorf("building artifact image request: %w", err)
@@ -173,7 +173,7 @@ func handleApplyCloudConfig(cmd CommandData) (string, error) {
 		return "", err
 	}
 
-	return "Cloud config written to /oem/99_daedalus_remote.yaml. Reboot to apply.", nil
+	return "Cloud config written to /oem/99_phonehome_remote.yaml. Reboot to apply.", nil
 }
 
 // handleReboot schedules a system reboot.
@@ -198,7 +198,7 @@ func writeOEMCloudConfig(content string) error {
 	// Best-effort mount — error is expected and ignored when /oem is already mounted.
 	_ = exec.Command("mount", "-L", "COS_OEM", "/oem").Run() //nosec G204 -- fixed label, called on local mountpoint
 
-	return os.WriteFile("/oem/99_daedalus_remote.yaml", []byte(content), 0600)
+	return os.WriteFile("/oem/99_phonehome_remote.yaml", []byte(content), 0600)
 }
 
 // scheduleReboot syncs filesystems and reboots after a short delay.

--- a/internal/phonehome/sysinfo.go
+++ b/internal/phonehome/sysinfo.go
@@ -39,7 +39,7 @@ func gatherSystemInfo() map[string]string {
 					break
 				}
 			}
-			f.Close()
+			_ = f.Close()
 		}
 
 		if f, err := os.Open("/proc/cpuinfo"); err == nil {
@@ -50,7 +50,7 @@ func gatherSystemInfo() map[string]string {
 					count++
 				}
 			}
-			f.Close()
+			_ = f.Close()
 			if count > 0 {
 				info["CPU_COUNT"] = strconv.Itoa(count)
 			}
@@ -62,12 +62,13 @@ func gatherSystemInfo() map[string]string {
 }
 
 // mergeEnvFile parses KEY=VALUE lines (optional quotes) and merges into dst.
+// path is always a compile-time constant in this package (see gatherSystemInfo).
 func mergeEnvFile(dst map[string]string, path string) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) //nosec G304 -- callers pass only fixed /etc/*-release paths
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/main.go
+++ b/main.go
@@ -1137,57 +1137,44 @@ The command automatically:
 			group := c.String("group")
 			heartbeat := c.Duration("heartbeat-interval")
 
-			// If url is empty, read from cloud-config using Kairos' config scanner
-			// which handles /oem/, /usr/local/cloud-config/ and subdirectories
-			if url == "" {
-				type phonehomeCC struct {
-					Phonehome struct {
-						URL               string            `yaml:"url"`
-						RegistrationToken string            `yaml:"registration_token"`
-						Group             string            `yaml:"group"`
-						Labels            map[string]string `yaml:"labels"`
-					} `yaml:"phonehome"`
-				}
-
-				cfg, err := agentConfig.Scan(
-					collector.Directories(constants.GetUserConfigDirs()...),
-					collector.NoLogs,
-				)
-				if err == nil {
-					// Re-parse the merged config to extract the phonehome section
-					configStr, _ := cfg.Collector.String()
-					var cc phonehomeCC
-					if yaml.Unmarshal([]byte(configStr), &cc) == nil && cc.Phonehome.URL != "" {
-						url = cc.Phonehome.URL
-						if token == "" {
-							token = cc.Phonehome.RegistrationToken
-						}
-						if group == "" {
-							group = cc.Phonehome.Group
-						}
-					}
+			// Pull phonehome defaults from cloud-config via the shared Collector.
+			// CLI flags still win: they override anything from the merged config.
+			var cfg phonehome.Config
+			scanned, err := agentConfig.Scan(
+				collector.Directories(constants.GetUserConfigDirs()...),
+				collector.NoLogs,
+			)
+			if err == nil {
+				if cc, ok, _ := phonehome.LoadFromCollector(scanned); ok {
+					cfg = *cc
 				}
 			}
 
-			if url == "" {
+			if url != "" {
+				cfg.URL = url
+			}
+			if token != "" {
+				cfg.RegistrationToken = token
+			}
+			if group != "" {
+				cfg.Group = group
+			}
+			cfg.HeartbeatInterval = heartbeat
+
+			if cfg.URL == "" {
 				return fmt.Errorf("phonehome URL required (use --url, DAEDALUS_URL env, or a phonehome: section in cloud-config)")
 			}
 
-			cfg := &phonehome.Config{
-				URL:               url,
-				RegistrationToken: token,
-				Group:             group,
-				HeartbeatInterval: heartbeat,
-			}
 			ctx := c.Context
 			var client *phonehome.Client
-			handler := phonehome.DefaultCommandHandler(url, func() string {
+			apiKeyFn := func() string {
 				if client != nil {
 					return client.APIKey()
 				}
 				return ""
-			})
-			client = phonehome.NewClient(cfg,
+			}
+			handler := phonehome.DefaultCommandHandler(cfg.URL, apiKeyFn, cfg.IsAllowed)
+			client = phonehome.NewClient(&cfg,
 				phonehome.WithCommandHandler(handler),
 			)
 			return client.Run(ctx)

--- a/main.go
+++ b/main.go
@@ -1108,22 +1108,22 @@ The command automatically:
 	},
 	{
 		Name:  "phone-home",
-		Usage: "Start phone-home connection to a Daedalus management server",
+		Usage: "Start phone-home connection to a management server",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "url",
-				Usage:   "Daedalus server URL",
-				EnvVars: []string{"DAEDALUS_URL"},
+				Usage:   "Phone-home server URL",
+				EnvVars: []string{"PHONEHOME_URL"},
 			},
 			&cli.StringFlag{
 				Name:    "token",
 				Usage:   "Registration token",
-				EnvVars: []string{"REGISTRATION_TOKEN"},
+				EnvVars: []string{"PHONEHOME_REGISTRATION_TOKEN"},
 			},
 			&cli.StringFlag{
 				Name:    "group",
 				Usage:   "Node group to join",
-				EnvVars: []string{"DAEDALUS_GROUP"},
+				EnvVars: []string{"PHONEHOME_GROUP"},
 			},
 			&cli.DurationFlag{
 				Name:  "heartbeat-interval",


### PR DESCRIPTION
Route phonehome cloud-config through the shared Collector via a new LoadFromCollector helper, dropping the duplicate filepath.Walk in internal/agent/phonehome_service.go and the inlined parsing in main.go.

Add Config.AllowedCommands with a conservative default set (upgrade, upgrade-recovery, reboot); DefaultCommandHandler now fails-closed and requires operators to opt destructive commands (exec, reset, apply-cloud-config) in explicitly. This narrows the blast radius of a DNS-hijack / rogue-server scenario.

Add a client_test.go spec that registers with a valid token but connects with a rejected API key, exercising the WebSocket auth path.

Sweep gosec findings: tighten /oem dir perms (0755→0750) and OEM cloud-config write perms (0644→0600), validate artifact IDs before building /tmp paths and image URLs, explicitly discard best-effort errors on shutdown paths, and annotate the remaining false positives (filesystem paths flagged as secrets, fixed-argument exec.Command calls) with //nosec + rationale.