### PR TITLE
fix(grub): skip shim copy on riscv64 EFI install

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -148,6 +148,8 @@ func GetFallBackEfi(arch string) string {
 	switch arch {
 	case ArchArm64:
 		return "bootaa64.efi"
+	case ArchRiscv64:
+		return "BOOTRISCV64.EFI"
 	default:
 		return "bootx64.efi"
 	}

--- a/pkg/utils/grub.go
+++ b/pkg/utils/grub.go
@@ -274,9 +274,14 @@ func (g Grub) Install(target, rootDir, bootDir, grubConf, tty string, efi bool, 
 		if strings.Contains(strings.ToLower(flavor), "alpine") && strings.Contains(strings.ToLower(model), "rpi") {
 			g.config.Logger.Debug("Running on Alpine+RPI, not copying shim or grub.")
 		} else {
-			err = g.copyShim()
-			if err != nil {
-				return err
+			// RISC-V has no shim package on Fedora/RHEL; firmware boots grub.efi directly.
+			if g.config.Arch != cnst.ArchRiscv64 {
+				err = g.copyShim()
+				if err != nil {
+					return err
+				}
+			} else {
+				g.config.Logger.Debug("Skipping shim copy for riscv64 - booting with grub EFI directly")
 			}
 			err = g.copyGrub()
 			if err != nil {
@@ -465,6 +470,13 @@ func (g Grub) copyGrub() error {
 		err = g.config.Fs.WriteFile(fileWriteName, fileContent, cnst.FilePerm)
 		if err != nil {
 			return fmt.Errorf("error writing %s: %s", fileWriteName, err)
+		}
+		if g.config.Arch == cnst.ArchRiscv64 {
+			fallback := cnst.GetFallBackEfi(g.config.Arch)
+			err = g.config.Fs.WriteFile(filepath.Join(cnst.EfiDir, "EFI/boot/", fallback), fileContent, cnst.FilePerm)
+			if err != nil {
+				return fmt.Errorf("could not write grub fallback %s at dir %s: %w", fallback, cnst.EfiDir, err)
+			}
 		}
 		grubDone = true
 		break

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -754,6 +754,39 @@ var _ = Describe("Utils", Label("utils"), func() {
 				Expect(err).To(BeNil())
 
 			})
+			It("installs with efi firmware on riscv64 without shim", Label("efi"), func() {
+				riscvConfig := agentConfig.NewConfig(
+					agentConfig.WithFs(fs),
+					agentConfig.WithRunner(runner),
+					agentConfig.WithLogger(logger),
+					agentConfig.WithMounter(mounter),
+					agentConfig.WithSyscall(syscall),
+					agentConfig.WithClient(client),
+					agentConfig.WithPlatform("linux/riscv64"),
+				)
+				// WithPlatform only updates Platform; Arch defaults to the host (x86_64 on CI).
+				riscvConfig.Arch = constants.ArchRiscv64
+				err := fsutils.MkdirAll(fs, filepath.Join(rootDir, "/usr/lib/grub/riscv64-efi/"), constants.DirPerm)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = fs.WriteFile(filepath.Join(rootDir, "/usr/lib/grub/riscv64-efi/grubriscv64.efi"), []byte("grub"), constants.FilePerm)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = fs.WriteFile(filepath.Join(rootDir, "/usr/lib/grub/riscv64-efi/loopback.mod"), []byte(""), constants.FilePerm)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = fsutils.MkdirAll(fs, filepath.Join(rootDir, "/etc/"), constants.DirPerm)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = fs.WriteFile(filepath.Join(rootDir, "/etc/os-release"), []byte("ID=\"fedora\""), constants.FilePerm)
+				Expect(err).ShouldNot(HaveOccurred())
+				grub := utils.NewGrub(riscvConfig)
+				err = grub.Install(target, rootDir, bootDir, constants.GrubConf, "", true, "COS_STATE")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				_, err = fs.Stat(filepath.Join(constants.EfiDir, "EFI/boot/grubriscv64.efi"))
+				Expect(err).To(BeNil())
+				_, err = fs.Stat(filepath.Join(constants.EfiDir, "EFI/boot/BOOTRISCV64.EFI"))
+				Expect(err).To(BeNil())
+				_, err = fs.Stat(filepath.Join(constants.EfiDir, "EFI/boot/", constants.SignedShim))
+				Expect(err).To(HaveOccurred())
+			})
 			It("fails with bios if no grub2-install file exists", func() {
 				Expect(fs.RemoveAll(filepath.Join(rootDir, "sbin", "grub2-install"))).ToNot(HaveOccurred())
 				grub := utils.NewGrub(config)


### PR DESCRIPTION
## Summary

- Skip `copyShim()` on `riscv64` during EFI installation; Fedora/RHEL ship `grub2-efi-riscv64` but no shim package for this architecture.
- Write `BOOTRISCV64.EFI` as the UEFI removable-media fallback when copying `grubriscv64.efi` (same approach as AuroraBoot ISO builder).
- Add unit test covering riscv64 EFI install without shim.

Fixes manual installation failure:

```
could not find any shim file to copy
```

reported while installing a Fedora-based riscv64 Kairos image.

## Context

`kairos-init` already installs `grub2-efi-riscv64` / `grub2-efi-riscv64-modules` and documents booting grub directly (no shim). AuroraBoot was updated in kairos-io/AuroraBoot#509; this aligns `kairos-agent` installer behavior.

Tracking: kairos-io/kairos#4083

## Test plan

- [x] Unit test: `installs with efi firmware on riscv64 without shim`
- [x] Manual: install Fedora riscv64 Kairos live ISO to disk via EFI; confirm install completes and system boots from installed ESP


Made with [Cursor](https://cursor.com)