### PR TITLE
fix(tui): paginate disk selection list when it overflows the terminal

### DIFF
--- a/internal/agent/TUIdiskPage.go
+++ b/internal/agent/TUIdiskPage.go
@@ -29,13 +29,17 @@ type diskSelectionPage struct {
 // + blank line.
 const diskPageHeaderLines = 4
 
+// visibleRows is the number of rows reserved by Model.View for page content
+// (height minus this value gives the usable content area).
+const visibleRows = 10
+
 // visibleCount returns how many disk rows fit in the available vertical space.
-// It mirrors the content budget applied by Model.View (height-10) and reserves
-// two lines for the scroll indicators when the list overflows.
+// It mirrors the content budget applied by Model.View (height-visibleRows) and
+// reserves two lines for the scroll indicators when the list overflows.
 func (p *diskSelectionPage) visibleCount() int {
 	_, height := effectiveSize(mainModel.width, mainModel.height)
-	// Model.View slices each page's content to height-10 lines.
-	avail := height - 10 - diskPageHeaderLines
+	// Model.View slices each page's content to height-visibleRows lines.
+	avail := height - visibleRows - diskPageHeaderLines
 	if len(p.disks) > avail {
 		// Reserve room for the top/bottom "..." scroll indicators.
 		avail -= 2

--- a/internal/agent/TUIdiskPage.go
+++ b/internal/agent/TUIdiskPage.go
@@ -21,6 +21,51 @@ type diskStruct struct {
 type diskSelectionPage struct {
 	disks  []diskStruct
 	cursor int
+	offset int // index of the first visible disk in the scroll window
+}
+
+// diskPageHeaderLines is the number of fixed lines the page renders before the
+// disk list: the "Select target disk" prompt + blank line, and the WARNING line
+// + blank line.
+const diskPageHeaderLines = 4
+
+// visibleCount returns how many disk rows fit in the available vertical space.
+// It mirrors the content budget applied by Model.View (height-10) and reserves
+// two lines for the scroll indicators when the list overflows.
+func (p *diskSelectionPage) visibleCount() int {
+	_, height := effectiveSize(mainModel.width, mainModel.height)
+	// Model.View slices each page's content to height-10 lines.
+	avail := height - 10 - diskPageHeaderLines
+	if len(p.disks) > avail {
+		// Reserve room for the top/bottom "..." scroll indicators.
+		avail -= 2
+	}
+	if avail < 1 {
+		avail = 1
+	}
+	return avail
+}
+
+// clampOffset keeps the scroll window so the cursor stays visible and the
+// offset never runs past the end of the list.
+func (p *diskSelectionPage) clampOffset() {
+	vc := p.visibleCount()
+	if p.cursor < p.offset {
+		p.offset = p.cursor
+	}
+	if p.cursor >= p.offset+vc {
+		p.offset = p.cursor - vc + 1
+	}
+	maxOffset := len(p.disks) - vc
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if p.offset > maxOffset {
+		p.offset = maxOffset
+	}
+	if p.offset < 0 {
+		p.offset = 0
+	}
 }
 
 func newDiskSelectionPage() *diskSelectionPage {
@@ -67,10 +112,12 @@ func (p *diskSelectionPage) Update(msg tea.Msg) (Page, tea.Cmd) {
 			if p.cursor > 0 {
 				p.cursor--
 			}
+			p.clampOffset()
 		case "down", "j":
 			if p.cursor < len(p.disks)-1 {
 				p.cursor++
 			}
+			p.clampOffset()
 		case "enter":
 			// Store selected disk in mainModel
 			if p.cursor >= 0 && p.cursor < len(p.disks) {
@@ -87,12 +134,28 @@ func (p *diskSelectionPage) View() string {
 	s := "Select target disk for installation:\n\n"
 	s += "WARNING: All data on the selected disk will be DESTROYED!\n\n"
 
-	for i, disk := range p.disks {
+	p.clampOffset()
+	vc := p.visibleCount()
+	start := p.offset
+	end := start + vc
+	if end > len(p.disks) {
+		end = len(p.disks)
+	}
+
+	indicatorStyle := lipgloss.NewStyle().Foreground(kairosText)
+	if start > 0 {
+		s += indicatorStyle.Render("  ... more above") + "\n"
+	}
+	for i := start; i < end; i++ {
+		disk := p.disks[i]
 		cursor := " "
 		if p.cursor == i {
 			cursor = lipgloss.NewStyle().Foreground(kairosAccent).Render(">")
 		}
 		s += fmt.Sprintf("%s %s (%s)\n", cursor, disk.name, disk.size)
+	}
+	if end < len(p.disks) {
+		s += indicatorStyle.Render("  ... more below") + "\n"
 	}
 
 	return s

--- a/internal/agent/TUIdiskPage_internal_test.go
+++ b/internal/agent/TUIdiskPage_internal_test.go
@@ -1,0 +1,107 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func makeDiskPage(n int) *diskSelectionPage {
+	disks := make([]diskStruct, n)
+	for i := 0; i < n; i++ {
+		disks[i] = diskStruct{id: i, name: "/dev/sd" + string(rune('a'+i)), size: "10.00 GiB"}
+	}
+	return &diskSelectionPage{disks: disks}
+}
+
+func pressDown(p *diskSelectionPage) {
+	p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+}
+
+func pressUp(p *diskSelectionPage) {
+	p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+}
+
+// cursorVisible reports whether the cursor index falls inside the scroll window.
+func cursorVisible(p *diskSelectionPage) bool {
+	vc := p.visibleCount()
+	return p.cursor >= p.offset && p.cursor < p.offset+vc
+}
+
+func TestDiskScrollCursorStaysVisible(t *testing.T) {
+	// Small terminal so the disk list overflows: height 24 -> ~10 visible rows.
+	mainModel = Model{width: 80, height: 24}
+	p := makeDiskPage(30)
+
+	if len(p.disks) <= p.visibleCount() {
+		t.Fatalf("test precondition: list (%d) should overflow visible window (%d)", len(p.disks), p.visibleCount())
+	}
+
+	// Walk all the way down. Cursor must remain inside the window at every step.
+	for i := 0; i < len(p.disks)-1; i++ {
+		pressDown(p)
+		if !cursorVisible(p) {
+			t.Fatalf("cursor %d not visible after %d downs: offset=%d visible=%d", p.cursor, i+1, p.offset, p.visibleCount())
+		}
+	}
+	if p.cursor != len(p.disks)-1 {
+		t.Fatalf("expected cursor at last disk %d, got %d", len(p.disks)-1, p.cursor)
+	}
+
+	// Walk back up. Same invariant.
+	for i := 0; i < len(p.disks)-1; i++ {
+		pressUp(p)
+		if !cursorVisible(p) {
+			t.Fatalf("cursor %d not visible after going up: offset=%d visible=%d", p.cursor, p.offset, p.visibleCount())
+		}
+	}
+	if p.cursor != 0 || p.offset != 0 {
+		t.Fatalf("expected cursor/offset back at 0, got cursor=%d offset=%d", p.cursor, p.offset)
+	}
+}
+
+func TestDiskScrollNoOverflowSmallList(t *testing.T) {
+	mainModel = Model{width: 80, height: 24}
+	p := makeDiskPage(3)
+
+	// No scroll indicators when everything fits.
+	out := p.View()
+	if strings.Contains(out, "more above") || strings.Contains(out, "more below") {
+		t.Fatalf("did not expect scroll indicators for a short list:\n%s", out)
+	}
+	if p.offset != 0 {
+		t.Fatalf("offset should stay 0 for short list, got %d", p.offset)
+	}
+}
+
+func TestDiskScrollIndicatorsAndViewBounds(t *testing.T) {
+	mainModel = Model{width: 80, height: 24}
+	p := makeDiskPage(30)
+
+	// At the top: only the "below" indicator.
+	top := p.View()
+	if strings.Contains(top, "more above") {
+		t.Fatalf("unexpected 'more above' at top of list:\n%s", top)
+	}
+	if !strings.Contains(top, "more below") {
+		t.Fatalf("expected 'more below' at top of long list:\n%s", top)
+	}
+
+	// Move into the middle: both indicators present.
+	for i := 0; i < 15; i++ {
+		pressDown(p)
+	}
+	mid := p.View()
+	if !strings.Contains(mid, "more above") || !strings.Contains(mid, "more below") {
+		t.Fatalf("expected both indicators in the middle:\n%s", mid)
+	}
+
+	// The rendered content must never exceed the Model.View slice budget
+	// (height-10). strings.Count counts trailing-newline-terminated rows.
+	_, h := effectiveSize(mainModel.width, mainModel.height)
+	budget := h - 10
+	if got := strings.Count(mid, "\n"); got > budget {
+		t.Fatalf("rendered %d content lines, exceeds budget %d", got, budget)
+	}
+}


### PR DESCRIPTION
The disk selection page rendered every disk in a flat loop with no height constraint. With many disks (10+) the cursor moved past the visible area and Model.View truncated the overflow, leaving the cursor inaccessible.

Add a scroll window: track an offset, compute how many rows fit (mirroring Model.View's height-10 budget minus the header lines), clamp the offset so the cursor is always visible, and render only the visible slice with "... more above/below" indicators when items are hidden.

Fixes https://github.com/kairos-io/kairos/issues/4128