### PR TITLE
feat(tui): interactive-install pre-installation checks

### DIFF
--- a/internal/agent/TUImodel.go
+++ b/internal/agent/TUImodel.go
@@ -63,6 +63,7 @@ func InitialModel(l *sdkLogger.KairosLogger, source string) Model {
 		log:             l,
 	}
 	mainModel.pages = []Page{
+		newPrerequisitesPage(),
 		newDiskSelectionPage(),
 		newInstallOptionsPage(),
 		newCustomizationPage(),

--- a/internal/agent/TUIprerequisitesPage.go
+++ b/internal/agent/TUIprerequisitesPage.go
@@ -1,0 +1,549 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/kairos-io/kairos-agent/v2/pkg/prereqs"
+	"github.com/mudler/go-pluggable"
+)
+
+// prerequisitesPage is the first screen of the interactive installer. It asks
+// provider plugins (via the EventChecks bus event) to inspect the live system
+// and return a set of pre-installation sanity checks / prerequisites. Each
+// check may carry an interactive prompt: yes/no, free text, single-select or
+// multi-select. The user reviews and answers them; on continue the answers are
+// sent back to the providers (EventChecksApply) which execute their actions
+// (e.g. wiping the disks the user selected) before the installation begins.
+//
+// When no provider returns any check the page auto-advances to disk selection,
+// so it is invisible on systems without prerequisites providers.
+type prerequisitesPage struct {
+	checks   []prereqs.Check
+	answers  map[string]prereqs.Answer  // by check ID
+	texts    map[string]textinput.Model // by check ID, for PromptText
+	fields   []prereqField              // flattened focusable items
+	mgr      *pluggable.Manager         // dedicated tui-check plugin manager
+	cursor   int
+	loaded   bool
+	applyErr string
+	failure  string // failNone | failRequired | failOptional
+	results  []prereqs.ApplyResult
+}
+
+const (
+	failNone     = ""
+	failRequired = "required"
+	failOptional = "optional"
+)
+
+// prereqField is a single focusable item on the page. A confirm/select/text
+// check maps to one field; a multiselect check maps to one field per option.
+type prereqField struct {
+	checkIdx int
+	kind     string // "confirm" | "select" | "text" | "option"
+	optIdx   int    // option index, for kind == "option"
+}
+
+func newPrerequisitesPage() *prerequisitesPage {
+	return &prerequisitesPage{
+		answers: map[string]prereqs.Answer{},
+		texts:   map[string]textinput.Model{},
+	}
+}
+
+func (p *prerequisitesPage) ID() string    { return "prerequisites" }
+func (p *prerequisitesPage) Title() string { return "Prerequisites" }
+
+func (p *prerequisitesPage) Help() string {
+	switch p.failure {
+	case failRequired:
+		return "enter: retry • q/ctrl+c: quit"
+	case failOptional:
+		return "enter: continue anyway • r: retry • q/ctrl+c: quit"
+	}
+	if len(p.fields) == 0 {
+		return "enter: continue"
+	}
+	return "↑/↓: move • ←/→ or space: change • enter: continue"
+}
+
+// Init gathers the checks from providers synchronously (go-pluggable runs
+// plugins inline), mirroring the customization page. With no checks it emits a
+// navigation message to skip straight to disk selection.
+func (p *prerequisitesPage) Init() tea.Cmd {
+	if !p.loaded {
+		p.mgr = newCheckManager(*mainModel.log)
+		checks, err := gatherChecks(p.mgr, *mainModel.log, "")
+		if err != nil {
+			mainModel.log.Logger.Warn().Err(err).Msg("gathering prerequisites checks")
+		}
+		p.checks = checks
+		p.buildFields()
+		p.loaded = true
+		mainModel.log.Logger.Debug().Int("checks", len(checks)).Int("fields", len(p.fields)).Msg("Prerequisites gathered")
+	}
+
+	if len(p.checks) == 0 {
+		return func() tea.Msg { return GoToPageMsg{PageID: "disk_selection"} }
+	}
+	return p.syncFocus()
+}
+
+// buildFields flattens the checks into focusable fields and seeds default
+// answers and text inputs.
+func (p *prerequisitesPage) buildFields() {
+	p.fields = nil
+	for i, c := range p.checks {
+		p.answers[c.ID] = prereqs.DefaultAnswer(c)
+		switch c.Prompt {
+		case prereqs.PromptConfirm:
+			p.fields = append(p.fields, prereqField{checkIdx: i, kind: "confirm"})
+		case prereqs.PromptSelect:
+			p.fields = append(p.fields, prereqField{checkIdx: i, kind: "select"})
+		case prereqs.PromptText:
+			ti := textinput.New()
+			ti.Placeholder = c.Placeholder
+			ti.SetValue(p.answers[c.ID].Text)
+			ti.Width = 40
+			p.texts[c.ID] = ti
+			p.fields = append(p.fields, prereqField{checkIdx: i, kind: "text"})
+		case prereqs.PromptMultiSelect:
+			for oi := range c.Options {
+				p.fields = append(p.fields, prereqField{checkIdx: i, kind: "option", optIdx: oi})
+			}
+		}
+	}
+}
+
+func (p *prerequisitesPage) Update(msg tea.Msg) (Page, tea.Cmd) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return p, nil
+	}
+
+	var cur *prereqField
+	if p.cursor >= 0 && p.cursor < len(p.fields) {
+		cur = &p.fields[p.cursor]
+	}
+
+	// Navigation keys that always apply, even inside a text field.
+	switch km.String() {
+	case "up":
+		p.moveCursor(-1)
+		return p, p.syncFocus()
+	case "down", "tab":
+		p.moveCursor(1)
+		return p, p.syncFocus()
+	case "shift+tab":
+		p.moveCursor(-1)
+		return p, p.syncFocus()
+	case "enter":
+		// After an optional-action failure, enter means "continue anyway".
+		if p.failure == failOptional {
+			return p, func() tea.Msg { return GoToPageMsg{PageID: "disk_selection"} }
+		}
+		return p.proceed()
+	}
+
+	// In a failure state, 'r' retries the apply (re-runs every decision) —
+	// but not while a text field is focused, where 'r' is a literal character.
+	if p.failure != failNone && (km.String() == "r" || km.String() == "R") &&
+		!(cur != nil && cur.kind == "text") {
+		return p.proceed()
+	}
+
+	// Text field: route everything else to the input.
+	if cur != nil && cur.kind == "text" {
+		c := p.checks[cur.checkIdx]
+		ti := p.texts[c.ID]
+		var cmd tea.Cmd
+		ti, cmd = ti.Update(msg)
+		p.texts[c.ID] = ti
+		a := p.answers[c.ID]
+		a.Text = ti.Value()
+		p.answers[c.ID] = a
+		// Editing an answer invalidates a previous failure.
+		p.clearFailure()
+		return p, cmd
+	}
+
+	// Non-text fields.
+	switch km.String() {
+	case "k":
+		p.moveCursor(-1)
+		return p, p.syncFocus()
+	case "j":
+		p.moveCursor(1)
+		return p, p.syncFocus()
+	case "left", "h":
+		p.control(cur, -1)
+	case "right", "l":
+		p.control(cur, +1)
+	case " ":
+		p.control(cur, 0)
+	}
+	return p, nil
+}
+
+func (p *prerequisitesPage) moveCursor(delta int) {
+	if len(p.fields) == 0 {
+		return
+	}
+	p.cursor += delta
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+	if p.cursor > len(p.fields)-1 {
+		p.cursor = len(p.fields) - 1
+	}
+}
+
+// control changes the value of the focused non-text field. dir -1/+1 are
+// directional (left/right); 0 means toggle (space).
+func (p *prerequisitesPage) control(cur *prereqField, dir int) {
+	if cur == nil {
+		return
+	}
+	// Changing an answer invalidates a previous failure.
+	p.clearFailure()
+	c := p.checks[cur.checkIdx]
+	a := p.answers[c.ID]
+
+	switch cur.kind {
+	case "confirm":
+		switch dir {
+		case -1:
+			a.Confirmed = false
+		case 1:
+			a.Confirmed = true
+		default:
+			a.Confirmed = !a.Confirmed
+		}
+	case "select":
+		next := cycleOption(c.Options, a.Selected, dir)
+		if next == "" {
+			a.Selected = nil
+		} else {
+			a.Selected = []string{next}
+		}
+		id := c.Options[cur.optIdx].ID
+		if dir == 1 {
+			a.Selected = addUnique(a.Selected, id)
+		} else if dir == -1 {
+			a.Selected = remove(a.Selected, id)
+		} else { // toggle
+			if contains(a.Selected, id) {
+				a.Selected = remove(a.Selected, id)
+			} else {
+				a.Selected = addUnique(a.Selected, id)
+			}
+		}
+	}
+	p.answers[c.ID] = a
+}
+
+// syncFocus focuses the text input under the cursor (if any) and blurs the
+// rest. Returns the blink command for the focused input.
+func (p *prerequisitesPage) syncFocus() tea.Cmd {
+	for id, ti := range p.texts {
+		ti.Blur()
+		p.texts[id] = ti
+	}
+	if p.cursor >= 0 && p.cursor < len(p.fields) {
+		f := p.fields[p.cursor]
+		if f.kind == "text" {
+			c := p.checks[f.checkIdx]
+			ti := p.texts[c.ID]
+			cmd := ti.Focus()
+			p.texts[c.ID] = ti
+			return cmd
+		}
+	}
+	return nil
+}
+
+// clearFailure resets any pending failure state so the user can retry from a
+// clean slate after changing an answer.
+func (p *prerequisitesPage) clearFailure() {
+	p.failure = failNone
+	p.applyErr = ""
+	p.results = nil
+}
+
+// advance returns the command that moves on to disk selection.
+func (p *prerequisitesPage) advance() tea.Cmd {
+	return func() tea.Msg { return GoToPageMsg{PageID: "disk_selection"} }
+}
+
+// proceed validates blockers, applies the user's decisions and advances to
+// disk selection.
+//
+//   - An unsatisfied blocking check keeps the user on the page (failRequired).
+//   - A failed Required action keeps the user on the page; enter retries
+//     (failRequired).
+//   - A failed optional action is surfaced as a warning; the user may continue
+//     anyway with enter or retry with 'r' (failOptional).
+func (p *prerequisitesPage) proceed() (Page, tea.Cmd) {
+	p.clearFailure()
+
+	if c, blocked := prereqs.Blocker(p.checks, p.answers); blocked {
+		p.failure = failRequired
+		p.applyErr = fmt.Sprintf("Cannot continue: %s — %s", c.Title, c.Message)
+		return p, nil
+	}
+
+	decisions := prereqs.BuildDecisions(p.checks, p.answers)
+	if len(decisions) > 0 {
+		results, err := applyDecisions(p.mgr, *mainModel.log, decisions, "")
+		if err != nil {
+			// A transport/exec failure is unrecoverable from here: block.
+			p.failure = failRequired
+			p.applyErr = fmt.Sprintf("Failed applying prerequisites: %s", err.Error())
+			return p, nil
+		}
+		p.results = results
+
+		reqFail, optFail := prereqs.ClassifyFailures(p.checks, results)
+		if len(reqFail) > 0 {
+			p.failure = failRequired
+			p.applyErr = "Required action(s) failed. Fix the issue and retry."
+			return p, nil
+		}
+		if len(optFail) > 0 {
+			p.failure = failOptional
+			p.applyErr = "Some optional action(s) failed. Press enter to continue or r to retry."
+			return p, nil
+		}
+	}
+
+	return p, p.advance()
+}
+
+func (p *prerequisitesPage) View() string {
+	s := "Pre-installation checks\n\n"
+	if !p.loaded {
+		return s + "Checking prerequisites...\n"
+	}
+
+	// Build the inner content of each box first, then render every box at one
+	// uniform width: the widest content, capped to the screen. This keeps the
+	// boxes aligned without stretching them across the whole screen.
+	inners := make([]string, len(p.checks))
+	contentW := 0
+	for i, c := range p.checks {
+		inners[i] = p.checkInner(i, c)
+		if lw := lipgloss.Width(inners[i]); lw > contentW {
+			contentW = lw
+		}
+	}
+	w, _ := effectiveSize(mainModel.width, mainModel.height)
+	if maxContent := w - 10; contentW > maxContent { // leave room for border + padding + page margin
+		contentW = maxContent
+	}
+	for i, c := range p.checks {
+		box := lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(severityColor(c.Severity)).
+			Background(kairosBg).
+			Padding(0, 1).
+			Width(contentW + 2). // +2 for the horizontal padding
+			Render(inners[i])
+		s += box + "\n"
+	}
+
+	if len(p.results) > 0 {
+		s += "\nResults:\n"
+		okStyle := lipgloss.NewStyle().Foreground(kairosAccent)
+		failStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+		for _, r := range p.results {
+			mark := okStyle.Render(checkMark)
+			if !r.Success {
+				mark = failStyle.Render("✗")
+			}
+			line := fmt.Sprintf("  %s %s", mark, r.ID)
+			if r.Message != "" {
+				line += ": " + r.Message
+			}
+			s += line + "\n"
+		}
+	}
+
+	if p.applyErr != "" {
+		style := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).Bold(true)
+		if p.failure == failOptional {
+			style = lipgloss.NewStyle().Foreground(kairosAccent).Bold(true)
+		}
+		s += "\n" + style.Render(p.applyErr) + "\n"
+	}
+	return s
+}
+
+// renderPrompt renders the interactive widget for a check, marking the focused
+// field.
+func (p *prerequisitesPage) renderPrompt(checkIdx int, c prereqs.Check) string {
+	a := p.answers[c.ID]
+	prompt := c.PromptText
+	cur := func(kind string, opt int) string {
+		if p.focused(checkIdx, kind, opt) {
+			return lipgloss.NewStyle().Foreground(kairosAccent).Render(">")
+		}
+		return " "
+	}
+	on := lipgloss.NewStyle().Foreground(kairosAccent)
+
+	switch c.Prompt {
+	case prereqs.PromptConfirm:
+		yes, no := "( ) yes", "( ) no"
+		if a.Confirmed {
+			yes = on.Render("(•) yes")
+		} else {
+			no = on.Render("(•) no")
+		}
+		return fmt.Sprintf("  %s %s  %s  %s\n", cur("confirm", 0), prompt, yes, no)
+	case prereqs.PromptSelect:
+		sel := ""
+		if len(a.Selected) > 0 {
+			sel = optionLabel(c.Options, a.Selected[0])
+		}
+		return fmt.Sprintf("  %s %s  < %s >\n", cur("select", 0), prompt, on.Render(sel))
+	case prereqs.PromptText:
+		ti := p.texts[c.ID]
+		return fmt.Sprintf("  %s %s %s\n", cur("text", 0), prompt, ti.View())
+	case prereqs.PromptMultiSelect:
+		out := ""
+		if prompt != "" {
+			out += "  " + prompt + "\n"
+		}
+		for oi, opt := range c.Options {
+			box := "[ ]"
+			if contains(a.Selected, opt.ID) {
+				box = on.Render("[" + checkMark + "]")
+			}
+			out += fmt.Sprintf("    %s %s %s\n", cur("option", oi), box, opt.Label)
+		}
+		return out
+	default:
+		return ""
+	}
+}
+
+// checkInner builds the content shown inside a check's box: the name on the
+// first line, then the message, then (with a blank line of breathing room) the
+// input widget.
+func (p *prerequisitesPage) checkInner(checkIdx int, c prereqs.Check) string {
+	title := fmt.Sprintf("[%s] %s", strings.ToUpper(severityName(c.Severity)), c.Title)
+	inner := severityStyle(c.Severity).Bold(true).Render(title)
+
+	if c.Message != "" {
+		inner += "\n" + c.Message
+	}
+	if prompt := p.renderPrompt(checkIdx, c); prompt != "" {
+		inner += "\n\n" + strings.TrimRight(prompt, "\n")
+	}
+	return inner
+}
+
+// focused reports whether the cursor is on the given field.
+func (p *prerequisitesPage) focused(checkIdx int, kind string, opt int) bool {
+	if p.cursor < 0 || p.cursor >= len(p.fields) {
+		return false
+	}
+	f := p.fields[p.cursor]
+	return f.checkIdx == checkIdx && f.kind == kind && (kind != "option" || f.optIdx == opt)
+}
+
+// --- small helpers ---
+
+func severityName(s string) string {
+	if s == "" {
+		return prereqs.SeverityInfo
+	}
+	return s
+}
+
+// severityColor maps a severity to a distinct color: blue (info), orange
+// (warning), red (error).
+func severityColor(severity string) lipgloss.Color {
+	switch severity {
+	case prereqs.SeverityError:
+		return lipgloss.Color("#ff5555")
+	case prereqs.SeverityWarning:
+		return kairosAccent
+	default:
+		return lipgloss.Color("#5fafff")
+	}
+}
+
+func severityStyle(severity string) lipgloss.Style {
+	s := lipgloss.NewStyle().Foreground(severityColor(severity))
+	if severity == prereqs.SeverityError {
+		s = s.Bold(true)
+	}
+	return s
+}
+
+func optionLabel(options []prereqs.Option, id string) string {
+	for _, o := range options {
+		if o.ID == id {
+			return o.Label
+		}
+	}
+	return id
+}
+
+// cycleOption returns the option ID after moving dir steps from the currently
+// selected one. With nothing selected, a forward move picks the first option.
+func cycleOption(options []prereqs.Option, selected []string, dir int) string {
+	if len(options) == 0 {
+		return ""
+	}
+	idx := 0
+	if len(selected) > 0 {
+		for i, o := range options {
+			if o.ID == selected[0] {
+				idx = i
+				break
+			}
+		}
+		idx += dir
+	} else if dir < 0 {
+		idx = len(options) - 1
+	}
+	if idx < 0 {
+		idx = len(options) - 1
+	}
+	if idx >= len(options) {
+		idx = 0
+	}
+	return options[idx].ID
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func addUnique(s []string, v string) []string {
+	if contains(s, v) {
+		return s
+	}
+	return append(s, v)
+}
+
+func remove(s []string, v string) []string {
+	out := s[:0:0]
+	for _, x := range s {
+		if x != v {
+			out = append(out, x)
+		}
+	}
+	return out
+}

--- a/internal/agent/prerequisites.go
+++ b/internal/agent/prerequisites.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"os"
+	"strings"
+
+	"github.com/kairos-io/kairos-agent/v2/pkg/prereqs"
+	sdkLogger "github.com/kairos-io/kairos-sdk/types/logger"
+	"github.com/mudler/go-pluggable"
+)
+
+// Interactive-install check plugins are a dedicated plugin set, separate from
+// the generic agent providers (agent-provider-* under /system/providers). They
+// are named tui-check-<name> and discovered in the directories below (plus the
+// current working directory, which is mostly useful for tests and development).
+const CheckPluginPrefix = "tui-check"
+
+// CheckPluginPaths are the directories scanned for tui-check-* plugins.
+var CheckPluginPaths = []string{"/system/tui-checks", "/usr/local/system/tui-checks"}
+
+// newCheckManager builds a go-pluggable manager dedicated to the
+// interactive-install check events and autoloads the tui-check-* plugins. It
+// deliberately does NOT install the global error->os.Exit handler that
+// internal/bus uses, so a misbehaving check plugin can never kill the TUI; all
+// problems are logged and surfaced through the returned data instead.
+func newCheckManager(log sdkLogger.KairosLogger) *pluggable.Manager {
+	m := pluggable.NewManager([]pluggable.EventType{prereqs.EventChecks, prereqs.EventChecksApply})
+
+	wd, _ := os.Getwd()
+	paths := append(append([]string{}, CheckPluginPaths...), wd)
+
+	log.Logger.Info().
+		Strs("paths", paths).
+		Str("prefix", CheckPluginPrefix+"-").
+		Msg("Discovering interactive-install check plugins")
+
+	m.Autoload(CheckPluginPrefix, paths...).Register()
+
+	if len(m.Plugins) == 0 {
+		log.Logger.Info().Strs("paths", paths).Msg("No interactive-install check plugins found")
+	}
+	for _, p := range m.Plugins {
+		log.Logger.Info().Str("name", p.Name).Str("executable", p.Executable).Msg("Found check plugin")
+	}
+	return m
+}
+
+// logPluginResponse logs everything a check plugin returned: its state/error,
+// the size of the data, and — crucially — its captured stdout/stderr (go-
+// pluggable puts the plugin's output in EventResponse.Logs, so this is the only
+// way the plugin's own logging reaches journald).
+func logPluginResponse(log sdkLogger.KairosLogger, phase string, p *pluggable.Plugin, r *pluggable.EventResponse) {
+	evt := log.Logger.Info().
+		Str("phase", phase).
+		Str("plugin", p.Name).
+		Str("executable", p.Executable).
+		Int("data_bytes", len(r.Data))
+	if r.State != "" {
+		evt = evt.Str("state", r.State)
+	}
+	if r.Error != "" {
+		evt = evt.Str("error", r.Error)
+	}
+	evt.Msg("Check plugin responded")
+
+	if strings.TrimSpace(r.Logs) != "" {
+		for line := range strings.SplitSeq(strings.TrimRight(r.Logs, "\n"), "\n") {
+			log.Logger.Info().Str("plugin", p.Name).Msgf("[%s] %s", p.Name, line)
+		}
+	}
+}
+
+// gatherChecks publishes the prerequisites check event on the dedicated manager
+// and collects the checks returned by every plugin. It is synchronous (go-
+// pluggable runs the plugins inline during Publish).
+func gatherChecks(m *pluggable.Manager, log sdkLogger.KairosLogger, config string) ([]prereqs.Check, error) {
+	var checks []prereqs.Check
+	var firstErr error
+
+	m.Response(prereqs.EventChecks, func(p *pluggable.Plugin, r *pluggable.EventResponse) {
+		logPluginResponse(log, "checks", p, r)
+		if r.Data == "" {
+			return
+		}
+		parsed, err := prereqs.ParseChecks(r.Data)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			log.Logger.Error().Err(err).Str("plugin", p.Name).Msg("Failed parsing checks from plugin")
+			return
+		}
+		log.Logger.Info().Str("plugin", p.Name).Int("checks", len(parsed)).Msg("Parsed checks from plugin")
+		checks = append(checks, parsed...)
+	})
+
+	log.Logger.Info().Str("event", string(prereqs.EventChecks)).Int("plugins", len(m.Plugins)).Msg("Publishing checks event to plugins")
+	if _, err := m.Publish(prereqs.EventChecks, prereqs.ChecksPayload{Config: config}); err != nil {
+		log.Logger.Error().Err(err).Msg("Failed publishing checks event")
+		return checks, err
+	}
+	log.Logger.Info().Int("checks", len(checks)).Msg("Collected checks from all plugins")
+	return checks, firstErr
+}
+
+// applyDecisions publishes the apply event with the user's decisions and
+// collects the results returned by every plugin.
+func applyDecisions(m *pluggable.Manager, log sdkLogger.KairosLogger, decisions []prereqs.Decision, config string) ([]prereqs.ApplyResult, error) {
+	var results []prereqs.ApplyResult
+	var firstErr error
+
+	m.Response(prereqs.EventChecksApply, func(p *pluggable.Plugin, r *pluggable.EventResponse) {
+		logPluginResponse(log, "apply", p, r)
+		if r.Data == "" {
+			return
+		}
+		parsed, err := prereqs.ParseApplyResults(r.Data)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			log.Logger.Error().Err(err).Str("plugin", p.Name).Msg("Failed parsing apply results from plugin")
+			return
+		}
+		results = append(results, parsed...)
+	})
+
+	log.Logger.Info().Str("event", string(prereqs.EventChecksApply)).Int("decisions", len(decisions)).Msg("Publishing apply event to plugins")
+	if _, err := m.Publish(prereqs.EventChecksApply, prereqs.ApplyPayload{Decisions: decisions, Config: config}); err != nil {
+		log.Logger.Error().Err(err).Msg("Failed publishing apply event")
+		return results, err
+	}
+	log.Logger.Info().Int("results", len(results)).Msg("Collected apply results from all plugins")
+	return results, firstErr
+}

--- a/internal/agent/prerequisites_test.go
+++ b/internal/agent/prerequisites_test.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/kairos-io/kairos-agent/v2/pkg/prereqs"
+	sdkLogger "github.com/kairos-io/kairos-sdk/types/logger"
+	"github.com/mudler/go-pluggable"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests exercise the prerequisites round-trip end to end against a real
+// tui-check plugin (the bash fixture under testdata/tui-checks). They build a
+// dedicated go-pluggable manager loaded only with the fixture, exactly like the
+// TUI page does — completely separate from the global agent-provider bus.
+var _ = Describe("Prerequisites round-trip", Label("prerequisites"), func() {
+	var m *pluggable.Manager
+	var log sdkLogger.KairosLogger
+	var applyLog string
+	var fixtureDir string
+
+	BeforeEach(func() {
+		var err error
+		fixtureDir, err = filepath.Abs("testdata/tui-checks")
+		Expect(err).ToNot(HaveOccurred())
+		// git should preserve the exec bit, but make sure.
+		Expect(os.Chmod(filepath.Join(fixtureDir, "tui-check-prereqtest"), 0o755)).To(Succeed())
+
+		f, err := os.CreateTemp("", "prereq-apply-*.log")
+		Expect(err).ToNot(HaveOccurred())
+		applyLog = f.Name()
+		Expect(f.Close()).To(Succeed())
+		Expect(os.Setenv("PREREQTEST_APPLY_LOG", applyLog)).To(Succeed())
+
+		log = sdkLogger.NewNullLogger()
+		m = pluggable.NewManager([]pluggable.EventType{prereqs.EventChecks, prereqs.EventChecksApply})
+		m.Autoload(CheckPluginPrefix, fixtureDir)
+		m.Register()
+	})
+
+	AfterEach(func() {
+		_ = os.Unsetenv("PREREQTEST_APPLY_LOG")
+		_ = os.Remove(applyLog)
+	})
+
+	It("loads the tui-check fixture plugin", func() {
+		Expect(m.Plugins).ToNot(BeEmpty())
+		Expect(m.Plugins[0].Name).To(Equal("prereqtest"))
+	})
+
+	It("gathers checks of every prompt type from the plugin", func() {
+		checks, err := gatherChecks(m, log, "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(checks).To(HaveLen(5))
+
+		byID := map[string]prereqs.Check{}
+		for _, c := range checks {
+			byID[c.ID] = c
+		}
+		Expect(byID["t-info"].Interactive()).To(BeFalse())
+		Expect(byID["t-confirm"].Prompt).To(Equal(prereqs.PromptConfirm))
+		Expect(byID["t-text"].Prompt).To(Equal(prereqs.PromptText))
+		Expect(byID["t-select"].Prompt).To(Equal(prereqs.PromptSelect))
+		Expect(byID["t-select"].Default).To(Equal("a"))
+		Expect(byID["t-multi"].Prompt).To(Equal(prereqs.PromptMultiSelect))
+		Expect(byID["t-multi"].Options).To(HaveLen(2))
+	})
+
+	It("sends the user's answers on apply and receives results", func() {
+		checks, err := gatherChecks(m, log, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		answers := map[string]prereqs.Answer{
+			"t-confirm": {Confirmed: true},
+			"t-text":    {Text: "node1"},
+			"t-select":  {Selected: []string{"b"}},
+			"t-multi":   {Selected: []string{"/dev/sdb", "/dev/sdc"}},
+		}
+		decisions := prereqs.BuildDecisions(checks, answers)
+		// 4 interactive checks (info is display-only).
+		Expect(decisions).To(HaveLen(4))
+
+		results, err := applyDecisions(m, log, decisions, "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		Expect(results[0].ID).To(Equal("t-multi"))
+		Expect(results[0].Success).To(BeTrue())
+
+		// The plugin recorded the payload it received: assert the user's
+		// answers crossed the bus intact.
+		logged, err := os.ReadFile(applyLog)
+		Expect(err).ToNot(HaveOccurred())
+		content := string(logged)
+		Expect(content).To(ContainSubstring("t-confirm"))
+		Expect(content).To(ContainSubstring("node1"))
+		Expect(content).To(ContainSubstring("/dev/sdb"))
+		Expect(content).To(ContainSubstring("/dev/sdc"))
+	})
+
+	It("surfaces apply failures and classifies them required vs optional", func() {
+		Expect(os.Setenv("PREREQTEST_FAIL", "1")).To(Succeed())
+		defer func() { _ = os.Unsetenv("PREREQTEST_FAIL") }()
+
+		checks, err := gatherChecks(m, log, "")
+		Expect(err).ToNot(HaveOccurred())
+		decisions := prereqs.BuildDecisions(checks, map[string]prereqs.Answer{
+			"t-multi": {Selected: []string{"/dev/sdb"}},
+		})
+		results, err := applyDecisions(m, log, decisions, "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		Expect(results[0].Success).To(BeFalse())
+		Expect(results[0].Message).To(Equal("boom"))
+
+		// Same failure classifies as required or optional purely by the
+		// check's Required flag.
+		rf, of := prereqs.ClassifyFailures([]prereqs.Check{{ID: "t-multi", Required: true}}, results)
+		Expect(rf).To(HaveLen(1))
+		Expect(of).To(BeEmpty())
+
+		rf, of = prereqs.ClassifyFailures([]prereqs.Check{{ID: "t-multi"}}, results)
+		Expect(rf).To(BeEmpty())
+		Expect(of).To(HaveLen(1))
+	})
+
+	It("a blocking unsatisfied check stops the install", func() {
+		checks := []prereqs.Check{
+			{ID: "ram", Title: "RAM", Severity: prereqs.SeverityError, Blocking: true},
+		}
+		_, blocked := prereqs.Blocker(checks, map[string]prereqs.Answer{})
+		Expect(blocked).To(BeTrue())
+	})
+})

--- a/internal/agent/testdata/tui-checks/tui-check-prereqtest
+++ b/internal/agent/testdata/tui-checks/tui-check-prereqtest
@@ -1,0 +1,26 @@
+#!/bin/bash
+# tui-check-prereqtest is a minimal interactive-install check plugin used only
+# by the prerequisites round-trip tests. It returns one check of every prompt
+# type and records the apply payload it receives to $PREREQTEST_APPLY_LOG. It
+# never performs any destructive action.
+event="$1"
+payload="$(cat)"
+
+case "$event" in
+  agent.interactive-install.checks)
+    echo '{"data":"[{\"id\":\"t-info\",\"title\":\"Info\",\"message\":\"hi\",\"severity\":\"info\"},{\"id\":\"t-confirm\",\"title\":\"Confirm\",\"severity\":\"warning\",\"prompt\":\"confirm\",\"promptText\":\"Proceed?\"},{\"id\":\"t-text\",\"title\":\"Text\",\"prompt\":\"text\",\"promptText\":\"Name?\",\"placeholder\":\"node\"},{\"id\":\"t-select\",\"title\":\"Select\",\"prompt\":\"select\",\"promptText\":\"Pick\",\"options\":[{\"id\":\"a\",\"label\":\"A\"},{\"id\":\"b\",\"label\":\"B\"}],\"default\":\"a\"},{\"id\":\"t-multi\",\"title\":\"Multi\",\"severity\":\"warning\",\"prompt\":\"multiselect\",\"promptText\":\"Disks\",\"options\":[{\"id\":\"/dev/sdb\",\"label\":\"sdb\"},{\"id\":\"/dev/sdc\",\"label\":\"sdc\"}]}]"}'
+    ;;
+  agent.interactive-install.checks.apply)
+    if [ -n "$PREREQTEST_APPLY_LOG" ]; then
+      printf '%s\n' "$payload" >> "$PREREQTEST_APPLY_LOG"
+    fi
+    if [ "$PREREQTEST_FAIL" = "1" ]; then
+      echo '{"data":"[{\"id\":\"t-multi\",\"success\":false,\"message\":\"boom\"}]"}'
+    else
+      echo '{"data":"[{\"id\":\"t-multi\",\"success\":true,\"message\":\"done\"}]"}'
+    fi
+    ;;
+  *)
+    echo '{}'
+    ;;
+esac

--- a/pkg/prereqs/prereqs.go
+++ b/pkg/prereqs/prereqs.go
@@ -1,0 +1,277 @@
+// Package prereqs defines the contract used by the interactive installer to
+// surface pre-installation sanity checks and prerequisites to the user.
+//
+// The flow mirrors the existing interactive-install customization mechanism
+// (see internal/agent/TUIcustomizationPage.go and the EventInteractiveInstall
+// bus event): the agent publishes a bus event, provider plugins inspect the
+// live system and respond with a list of checks. The TUI renders them on a
+// dedicated screen *before* the installation starts. Each check may carry an
+// interactive prompt (yes/no, free text, single- or multi-select). When the
+// user answers, the agent publishes a second "apply" event carrying the user's
+// decisions and the same provider executes the action (e.g. wiping the disks
+// the user selected).
+//
+// Providers must report check failures through the returned Check data
+// (Severity == SeverityError), NOT through the go-pluggable EventResponse.Error
+// field: the agent bus installs a global handler that aborts the process when a
+// provider returns an error, which would kill the TUI abruptly.
+package prereqs
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/mudler/go-pluggable"
+)
+
+const (
+	// EventChecks is published by the agent when the prerequisites screen
+	// opens. Providers respond with a JSON-encoded []Check in
+	// EventResponse.Data.
+	EventChecks pluggable.EventType = "agent.interactive-install.checks"
+
+	// EventChecksApply is published by the agent after the user has answered
+	// the checks. The payload is an ApplyPayload. Providers act on the
+	// decisions matching their own check IDs and respond with a JSON-encoded
+	// []ApplyResult in EventResponse.Data.
+	EventChecksApply pluggable.EventType = "agent.interactive-install.checks.apply"
+)
+
+// Severity levels for a Check.
+const (
+	SeverityInfo    = "info"
+	SeverityWarning = "warning"
+	SeverityError   = "error"
+)
+
+// Prompt types a check may carry. PromptNone is a display-only check.
+const (
+	PromptNone        = ""            // display only, no user input
+	PromptConfirm     = "confirm"     // yes/no
+	PromptText        = "text"        // free string input
+	PromptSelect      = "select"      // pick exactly one of Options
+	PromptMultiSelect = "multiselect" // pick zero or more of Options
+)
+
+// Option is a single choice for PromptSelect / PromptMultiSelect checks.
+type Option struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// Check is a single prerequisite/sanity check returned by a provider.
+type Check struct {
+	// ID is a stable identifier. It is echoed back to the provider in the apply
+	// round-trip so the provider knows which action to run. Providers should
+	// namespace it, e.g. "diskwipe".
+	ID string `json:"id"`
+	// Title is a short label shown to the user.
+	Title string `json:"title"`
+	// Message is the detail shown to the user.
+	Message string `json:"message"`
+	// Severity is one of SeverityInfo, SeverityWarning or SeverityError.
+	Severity string `json:"severity"`
+	// Blocking, when true, prevents the installation from proceeding until the
+	// check is satisfied (see Satisfied). A blocking display-only check (no
+	// prompt) can never be satisfied from the TUI and represents a hard,
+	// unrecoverable prerequisite failure (e.g. unsupported architecture).
+	Blocking bool `json:"blocking"`
+	// Required governs what happens when the check's apply action fails. When
+	// true, an apply failure blocks the installation (the user can retry or
+	// abort). When false (the default), an apply failure is surfaced as a
+	// warning and the user may continue anyway.
+	Required bool `json:"required"`
+
+	// Prompt selects the interactive widget: PromptNone, PromptConfirm,
+	// PromptText, PromptSelect or PromptMultiSelect.
+	Prompt string `json:"prompt"`
+	// PromptText is the question shown above/next to the widget.
+	PromptText string `json:"promptText"`
+	// Options are the choices for PromptSelect / PromptMultiSelect.
+	Options []Option `json:"options"`
+	// Default is the default answer: "yes"/"no" for confirm, the default text
+	// for text, an Option ID for select, or comma-separated Option IDs for
+	// multiselect.
+	Default string `json:"default"`
+	// Placeholder is the hint shown in an empty text input.
+	Placeholder string `json:"placeholder"`
+}
+
+// Interactive reports whether the check asks the user for input.
+func (c Check) Interactive() bool { return c.Prompt != PromptNone }
+
+// IsError reports whether the check has error severity.
+func (c Check) IsError() bool { return c.Severity == SeverityError }
+
+// Answer holds the user's response to a check. The relevant field depends on
+// the check's Prompt type.
+type Answer struct {
+	Confirmed bool     `json:"confirmed"` // PromptConfirm
+	Text      string   `json:"text"`      // PromptText
+	Selected  []string `json:"selected"`  // PromptSelect (len 1) / PromptMultiSelect
+}
+
+// Decision is the user's answer to a check, sent back to providers on apply.
+// It echoes the prompt type so providers know which field to read.
+type Decision struct {
+	ID        string   `json:"id"`
+	Prompt    string   `json:"prompt"`
+	Confirmed bool     `json:"confirmed,omitempty"`
+	Text      string   `json:"text,omitempty"`
+	Selected  []string `json:"selected,omitempty"`
+}
+
+// ChecksPayload is published on EventChecks.
+type ChecksPayload struct {
+	// Config is the current (possibly partial) cloud-config, for providers
+	// that want to take it into account. Providers mostly inspect the live
+	// system instead.
+	Config string `json:"config"`
+}
+
+// ApplyPayload is published on EventChecksApply.
+type ApplyPayload struct {
+	Decisions []Decision `json:"decisions"`
+	Config    string     `json:"config"`
+}
+
+// ApplyResult is what a provider returns after applying decisions.
+type ApplyResult struct {
+	ID      string `json:"id"`
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+// ParseChecks unmarshals the JSON-encoded []Check returned by a provider in
+// EventResponse.Data. An empty string yields a nil slice and no error.
+func ParseChecks(data string) ([]Check, error) {
+	if data == "" {
+		return nil, nil
+	}
+	var checks []Check
+	if err := json.Unmarshal([]byte(data), &checks); err != nil {
+		return nil, err
+	}
+	return checks, nil
+}
+
+// ParseApplyResults unmarshals the JSON-encoded []ApplyResult returned by a
+// provider. An empty string yields a nil slice and no error.
+func ParseApplyResults(data string) ([]ApplyResult, error) {
+	if data == "" {
+		return nil, nil
+	}
+	var results []ApplyResult
+	if err := json.Unmarshal([]byte(data), &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// HasPrompts reports whether any check asks the user for input.
+func HasPrompts(checks []Check) bool {
+	for _, c := range checks {
+		if c.Interactive() {
+			return true
+		}
+	}
+	return false
+}
+
+// Satisfied reports whether the user's answer resolves the check. A
+// display-only check is never satisfied. This is used to decide whether a
+// blocking check still blocks the installation.
+func Satisfied(c Check, a Answer) bool {
+	switch c.Prompt {
+	case PromptConfirm:
+		return a.Confirmed
+	case PromptText:
+		return a.Text != ""
+	case PromptSelect, PromptMultiSelect:
+		return len(a.Selected) > 0
+	default:
+		return false
+	}
+}
+
+// Blocker returns the first blocking check that is not yet satisfied and true,
+// or a zero Check and false when nothing blocks the installation.
+func Blocker(checks []Check, answers map[string]Answer) (Check, bool) {
+	for _, c := range checks {
+		if !c.Blocking {
+			continue
+		}
+		if Satisfied(c, answers[c.ID]) {
+			continue
+		}
+		return c, true
+	}
+	return Check{}, false
+}
+
+// BuildDecisions returns one Decision per interactive check, carrying the
+// user's answer and echoing the prompt type.
+func BuildDecisions(checks []Check, answers map[string]Answer) []Decision {
+	var out []Decision
+	for _, c := range checks {
+		if !c.Interactive() {
+			continue
+		}
+		a := answers[c.ID]
+		out = append(out, Decision{
+			ID:        c.ID,
+			Prompt:    c.Prompt,
+			Confirmed: a.Confirmed,
+			Text:      a.Text,
+			Selected:  a.Selected,
+		})
+	}
+	return out
+}
+
+// ClassifyFailures splits the failed apply results into those belonging to a
+// Required check and those belonging to an optional check, matched by ID.
+// Results with Success == true are ignored. A required failure blocks the
+// installation; an optional failure is a warning the user can continue past.
+func ClassifyFailures(checks []Check, results []ApplyResult) (requiredFailed, optionalFailed []ApplyResult) {
+	required := map[string]bool{}
+	for _, c := range checks {
+		required[c.ID] = c.Required
+	}
+	for _, r := range results {
+		if r.Success {
+			continue
+		}
+		if required[r.ID] {
+			requiredFailed = append(requiredFailed, r)
+		} else {
+			optionalFailed = append(optionalFailed, r)
+		}
+	}
+	return requiredFailed, optionalFailed
+}
+
+// DefaultAnswer returns the initial answer for a check based on its Default.
+func DefaultAnswer(c Check) Answer {
+	switch c.Prompt {
+	case PromptConfirm:
+		return Answer{Confirmed: c.Default == "yes" || c.Default == "true"}
+	case PromptText:
+		return Answer{Text: c.Default}
+	case PromptSelect:
+		if c.Default != "" {
+			return Answer{Selected: []string{c.Default}}
+		}
+	case PromptMultiSelect:
+		if c.Default != "" {
+			var sel []string
+			for part := range strings.SplitSeq(c.Default, ",") {
+				if part = strings.TrimSpace(part); part != "" {
+					sel = append(sel, part)
+				}
+			}
+			return Answer{Selected: sel}
+		}
+	}
+	return Answer{}
+}

--- a/pkg/prereqs/prereqs_suite_test.go
+++ b/pkg/prereqs/prereqs_suite_test.go
@@ -1,0 +1,13 @@
+package prereqs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPrereqs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Prereqs Suite")
+}

--- a/pkg/prereqs/prereqs_test.go
+++ b/pkg/prereqs/prereqs_test.go
@@ -1,0 +1,182 @@
+package prereqs_test
+
+import (
+	"github.com/kairos-io/kairos-agent/v2/pkg/prereqs"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Prereqs contract", func() {
+	Describe("ParseChecks", func() {
+		It("returns nil for an empty payload", func() {
+			checks, err := prereqs.ParseChecks("")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(checks).To(BeNil())
+		})
+		It("parses a list of checks with prompt metadata", func() {
+			data := `[{"id":"diskwipe","title":"Leftover data","message":"found disks","severity":"warning","prompt":"multiselect","promptText":"Select disks","options":[{"id":"/dev/sdb","label":"/dev/sdb"}]}]`
+			checks, err := prereqs.ParseChecks(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(checks).To(HaveLen(1))
+			Expect(checks[0].ID).To(Equal("diskwipe"))
+			Expect(checks[0].Severity).To(Equal(prereqs.SeverityWarning))
+			Expect(checks[0].Prompt).To(Equal(prereqs.PromptMultiSelect))
+			Expect(checks[0].Options).To(HaveLen(1))
+			Expect(checks[0].Interactive()).To(BeTrue())
+		})
+		It("errors on malformed JSON", func() {
+			_, err := prereqs.ParseChecks("{not json")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("ParseApplyResults", func() {
+		It("returns nil for an empty payload", func() {
+			res, err := prereqs.ParseApplyResults("")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(BeNil())
+		})
+		It("parses results", func() {
+			res, err := prereqs.ParseApplyResults(`[{"id":"diskwipe","success":true,"message":"wiped"}]`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(HaveLen(1))
+			Expect(res[0].Success).To(BeTrue())
+		})
+	})
+
+	Describe("Interactive / IsError", func() {
+		It("classifies prompt and severity", func() {
+			Expect(prereqs.Check{Prompt: prereqs.PromptNone}.Interactive()).To(BeFalse())
+			Expect(prereqs.Check{Prompt: prereqs.PromptConfirm}.Interactive()).To(BeTrue())
+			Expect(prereqs.Check{Severity: prereqs.SeverityError}.IsError()).To(BeTrue())
+			Expect(prereqs.Check{Severity: prereqs.SeverityInfo}.IsError()).To(BeFalse())
+		})
+	})
+
+	Describe("Satisfied", func() {
+		It("display-only checks are never satisfied", func() {
+			Expect(prereqs.Satisfied(prereqs.Check{Prompt: prereqs.PromptNone}, prereqs.Answer{})).To(BeFalse())
+		})
+		It("confirm is satisfied when confirmed", func() {
+			c := prereqs.Check{Prompt: prereqs.PromptConfirm}
+			Expect(prereqs.Satisfied(c, prereqs.Answer{Confirmed: false})).To(BeFalse())
+			Expect(prereqs.Satisfied(c, prereqs.Answer{Confirmed: true})).To(BeTrue())
+		})
+		It("text is satisfied when non-empty", func() {
+			c := prereqs.Check{Prompt: prereqs.PromptText}
+			Expect(prereqs.Satisfied(c, prereqs.Answer{})).To(BeFalse())
+			Expect(prereqs.Satisfied(c, prereqs.Answer{Text: "x"})).To(BeTrue())
+		})
+		It("select/multiselect satisfied when something is chosen", func() {
+			Expect(prereqs.Satisfied(prereqs.Check{Prompt: prereqs.PromptSelect}, prereqs.Answer{})).To(BeFalse())
+			Expect(prereqs.Satisfied(prereqs.Check{Prompt: prereqs.PromptSelect}, prereqs.Answer{Selected: []string{"a"}})).To(BeTrue())
+			Expect(prereqs.Satisfied(prereqs.Check{Prompt: prereqs.PromptMultiSelect}, prereqs.Answer{Selected: []string{"a", "b"}})).To(BeTrue())
+		})
+		It("multiselect with an empty selection is not satisfied", func() {
+			Expect(prereqs.Satisfied(prereqs.Check{Prompt: prereqs.PromptMultiSelect}, prereqs.Answer{Selected: []string{}})).To(BeFalse())
+			Expect(prereqs.Satisfied(prereqs.Check{Prompt: prereqs.PromptMultiSelect}, prereqs.Answer{})).To(BeFalse())
+		})
+	})
+
+	Describe("Blocker", func() {
+		It("returns false when nothing blocks", func() {
+			checks := []prereqs.Check{
+				{ID: "a", Severity: prereqs.SeverityInfo},
+				{ID: "b", Severity: prereqs.SeverityWarning},
+			}
+			_, blocked := prereqs.Blocker(checks, nil)
+			Expect(blocked).To(BeFalse())
+		})
+		It("blocks on a non-interactive blocking check forever", func() {
+			checks := []prereqs.Check{{ID: "arch", Severity: prereqs.SeverityError, Blocking: true}}
+			c, blocked := prereqs.Blocker(checks, map[string]prereqs.Answer{})
+			Expect(blocked).To(BeTrue())
+			Expect(c.ID).To(Equal("arch"))
+		})
+		It("a blocking confirm unblocks once confirmed", func() {
+			checks := []prereqs.Check{{ID: "ack", Blocking: true, Prompt: prereqs.PromptConfirm}}
+			_, blocked := prereqs.Blocker(checks, map[string]prereqs.Answer{})
+			Expect(blocked).To(BeTrue())
+			_, blocked = prereqs.Blocker(checks, map[string]prereqs.Answer{"ack": {Confirmed: true}})
+			Expect(blocked).To(BeFalse())
+		})
+	})
+
+	Describe("BuildDecisions", func() {
+		It("emits one decision per interactive check carrying the answer", func() {
+			checks := []prereqs.Check{
+				{ID: "info", Prompt: prereqs.PromptNone},
+				{ID: "ack", Prompt: prereqs.PromptConfirm},
+				{ID: "name", Prompt: prereqs.PromptText},
+				{ID: "disks", Prompt: prereqs.PromptMultiSelect},
+			}
+			answers := map[string]prereqs.Answer{
+				"ack":   {Confirmed: true},
+				"name":  {Text: "node1"},
+				"disks": {Selected: []string{"/dev/sdb", "/dev/sdc"}},
+			}
+			decisions := prereqs.BuildDecisions(checks, answers)
+			Expect(decisions).To(HaveLen(3))
+			Expect(decisions).To(ContainElement(prereqs.Decision{ID: "ack", Prompt: prereqs.PromptConfirm, Confirmed: true}))
+			Expect(decisions).To(ContainElement(prereqs.Decision{ID: "name", Prompt: prereqs.PromptText, Text: "node1"}))
+			Expect(decisions).To(ContainElement(prereqs.Decision{ID: "disks", Prompt: prereqs.PromptMultiSelect, Selected: []string{"/dev/sdb", "/dev/sdc"}}))
+		})
+		It("returns nil when no check is interactive", func() {
+			checks := []prereqs.Check{{ID: "info", Prompt: prereqs.PromptNone}}
+			Expect(prereqs.BuildDecisions(checks, nil)).To(BeNil())
+		})
+	})
+
+	Describe("ClassifyFailures", func() {
+		checks := []prereqs.Check{
+			{ID: "req", Required: true},
+			{ID: "opt", Required: false},
+		}
+		It("ignores successful results", func() {
+			rf, of := prereqs.ClassifyFailures(checks, []prereqs.ApplyResult{
+				{ID: "req", Success: true},
+				{ID: "opt", Success: true},
+			})
+			Expect(rf).To(BeEmpty())
+			Expect(of).To(BeEmpty())
+		})
+		It("buckets failures by the check's Required flag", func() {
+			rf, of := prereqs.ClassifyFailures(checks, []prereqs.ApplyResult{
+				{ID: "req", Success: false, Message: "boom"},
+				{ID: "opt", Success: false, Message: "meh"},
+			})
+			Expect(rf).To(HaveLen(1))
+			Expect(rf[0].ID).To(Equal("req"))
+			Expect(of).To(HaveLen(1))
+			Expect(of[0].ID).To(Equal("opt"))
+		})
+		It("treats an unknown ID as optional", func() {
+			rf, of := prereqs.ClassifyFailures(checks, []prereqs.ApplyResult{
+				{ID: "ghost", Success: false},
+			})
+			Expect(rf).To(BeEmpty())
+			Expect(of).To(HaveLen(1))
+		})
+	})
+
+	Describe("DefaultAnswer", func() {
+		It("seeds confirm from default yes", func() {
+			Expect(prereqs.DefaultAnswer(prereqs.Check{Prompt: prereqs.PromptConfirm, Default: "yes"}).Confirmed).To(BeTrue())
+			Expect(prereqs.DefaultAnswer(prereqs.Check{Prompt: prereqs.PromptConfirm, Default: "no"}).Confirmed).To(BeFalse())
+		})
+		It("seeds text and select from default", func() {
+			Expect(prereqs.DefaultAnswer(prereqs.Check{Prompt: prereqs.PromptText, Default: "hi"}).Text).To(Equal("hi"))
+			Expect(prereqs.DefaultAnswer(prereqs.Check{Prompt: prereqs.PromptSelect, Default: "opt1"}).Selected).To(Equal([]string{"opt1"}))
+		})
+		It("seeds multiselect from a comma-separated default", func() {
+			a := prereqs.DefaultAnswer(prereqs.Check{Prompt: prereqs.PromptMultiSelect, Default: "/dev/sdb, /dev/sdc"})
+			Expect(a.Selected).To(Equal([]string{"/dev/sdb", "/dev/sdc"}))
+		})
+		It("returns an empty answer for multiselect with no default", func() {
+			Expect(prereqs.DefaultAnswer(prereqs.Check{Prompt: prereqs.PromptMultiSelect}).Selected).To(BeNil())
+		})
+		It("returns an empty answer for a display-only check", func() {
+			Expect(prereqs.DefaultAnswer(prereqs.Check{Prompt: prereqs.PromptNone, Default: "x"})).To(Equal(prereqs.Answer{}))
+		})
+	})
+})

--- a/tui-check-examples/interactive-install-prerequisites.md
+++ b/tui-check-examples/interactive-install-prerequisites.md
@@ -1,0 +1,240 @@
+# Interactive install: pre-installation checks (prerequisites)
+
+The interactive installer (`kairos-agent interactive-install`) shows a
+**Prerequisites** screen before anything else. On that screen, provider plugins
+inspect the live system and return a list of *checks* — sanity checks,
+prerequisite validations, or actions that need the user's acknowledgement. The
+user reviews and answers them, and the providers then act on those answers
+before the installation begins.
+
+It reuses the same `go-pluggable` plugin protocol as the rest of the agent, but
+the check plugins are a **separate plugin set** with their own name and
+directories (see "Plugin discovery" below) so they never mix with the generic
+agent providers (`agent-provider-*`).
+
+Two working examples live under `tui-check-examples/`:
+
+- [`tui-check-diskwipe`](tui-check-diskwipe) — an **optional**
+  multi-select check: detects disks that still hold partitions from a previous
+  Kairos installation and offers to wipe the ones the user selects.
+- [`tui-check-magicword`](tui-check-magicword) — a **required**
+  text check: the install won't continue until the user types the magic word,
+  demonstrating text input, the answer round-trip and the retry path.
+
+## Scope
+
+- **Interactive TUI install only.** The non-interactive paths (`manual-install`,
+  auto/unattended install, the web UI) do not run these checks.
+- The screen runs **before disk selection** and before `RunInstall`, so it is
+  identical for UKI and non-UKI installs.
+- If no provider returns any check, the screen is skipped entirely (it never
+  shows an empty page).
+
+## Flow
+
+```
+TUI opens
+  │
+  ├─ publish  agent.interactive-install.checks         ──▶ providers inspect system
+  │                                                         return []Check
+  ├─ render checks, collect the user's answers
+  │
+  ├─ on "continue":
+  │     ├─ if a blocking check is unsatisfied → stay on the screen
+  │     └─ publish agent.interactive-install.checks.apply ──▶ providers act on the
+  │                (carries the user's decisions)              confirmed/selected
+  │                                                            answers, return []ApplyResult
+  └─ advance to disk selection
+```
+
+Both events go over the standard kairos-agent plugin bus (`go-pluggable`); the
+publish is synchronous (the plugin binaries run inline), so the round-trip
+completes before the screen advances.
+
+## Events
+
+| Event                                    | Direction         | Payload (sent)  | Response data (returned by provider) |
+|------------------------------------------|-------------------|-----------------|--------------------------------------|
+| `agent.interactive-install.checks`       | agent → providers | `ChecksPayload` | JSON `[]Check`                       |
+| `agent.interactive-install.checks.apply` | agent → providers | `ApplyPayload`  | JSON `[]ApplyResult`                 |
+
+Constants and types are defined in
+[`pkg/prereqs`](../pkg/prereqs/prereqs.go).
+
+## Data types
+
+### Check (provider → agent)
+
+```go
+type Check struct {
+    ID          string   // stable id, echoed back on apply (namespace it, e.g. "diskwipe")
+    Title       string   // short label
+    Message     string   // detail shown to the user
+    Severity    string   // "info" | "warning" | "error"
+    Blocking    bool     // if true, install can't proceed until the check is satisfied (answered)
+    Required    bool     // if true, a failed apply action blocks the install; if false, it's a warning
+    Prompt      string   // "" | "confirm" | "text" | "select" | "multiselect"
+    PromptText  string   // the question shown next to the widget
+    Options     []Option // choices for select/multiselect ({ID, Label})
+    Default     string   // "yes"/"no" (confirm), default text, an Option ID (select), or comma-separated Option IDs (multiselect)
+    Placeholder string   // hint for an empty text input
+}
+```
+
+### Decision (agent → provider, on apply)
+
+```go
+type Decision struct {
+    ID        string   // matches Check.ID
+    Prompt    string   // echo of the check's Prompt type
+    Confirmed bool     // PromptConfirm
+    Text      string   // PromptText
+    Selected  []string // PromptSelect (one element) / PromptMultiSelect (zero or more Option IDs)
+}
+```
+
+`ApplyPayload` wraps `[]Decision` (plus the current cloud-config); `ApplyResult`
+is `{ID, Success, Message}`.
+
+## Prompt types
+
+| Prompt        | Widget                     | Answer field               |
+|---------------|----------------------------|----------------------------|
+| `""` (none)   | display only, no input     | —                          |
+| `confirm`     | yes/no toggle              | `Confirmed`                |
+| `text`        | free-text input            | `Text`                     |
+| `select`      | cycle through `Options`    | `Selected` (one Option ID) |
+| `multiselect` | checkbox list of `Options` | `Selected` (Option IDs)    |
+
+## Severity and blocking
+
+- `info` / `warning`: shown; the install proceeds.
+- `error`: shown in red. Combine with `Blocking: true` for a hard prerequisite.
+- `Blocking: true`: the install cannot continue until the check is *satisfied*:
+  - a `confirm` check is satisfied once confirmed;
+  - a `text` check once non-empty;
+  - a `select`/`multiselect` check once at least one option is chosen;
+  - a **display-only** blocking check can never be satisfied from the TUI — use
+    it for unrecoverable failures (e.g. unsupported architecture, not enough
+    RAM) where the only option is to quit.
+
+## Failure handling
+
+`Blocking` and `Required` are two independent gates:
+
+- **`Blocking`** is a *pre-apply* gate. A blocking check must be *satisfied*
+  (answered) before the user can continue. A blocking display-only check can
+  never be satisfied and represents a hard, unrecoverable prerequisite.
+- **`Required`** is a *post-apply* gate. It controls what happens when the
+  provider's action fails (`ApplyResult.Success == false`):
+  - **Required** (`Required: true`): the failure blocks the install. The screen
+    shows the error in red; **enter retries** the apply, `q`/`ctrl+c` aborts.
+  - **Optional** (`Required: false`, the default): the failure is shown as a
+    warning; the user may **press enter to continue anyway**, or **`r` to
+    retry**.
+
+Changing any answer clears a pending failure, so the user can adjust their
+selection (e.g. deselect the disk that failed to wipe) and continue or retry
+from a clean state. A transport/exec error talking to the provider is always
+treated as blocking.
+
+All checks render in a **single list** on one screen; the user answers each and
+a **single combined apply** runs on continue. Providers return one
+`ApplyResult` per action they performed, so partial failures (e.g. 2 of 3 disks
+wiped) are reported individually and classified by their check's `Required`
+flag.
+
+After an apply attempt, the screen shows a per-action results summary
+(`✓`/`✗` with the provider's message) so the user can see exactly which actions
+succeeded and which failed before deciding to retry or continue.
+
+The example diskwipe provider leaves `Required` unset (optional): failing to
+wipe a leftover *secondary* disk should not stop an install targeting a
+different disk.
+
+## Plugin discovery
+
+Check plugins are discovered separately from the generic agent providers:
+
+- **Name:** the executable must be named `tui-check-<name>` (prefix
+  `tui-check-`), *not* `agent-provider-*`.
+- **Directories:** `/system/tui-checks`, `/usr/local/system/tui-checks`, and the
+  agent's working directory (handy for development/tests). `$PATH` is also
+  scanned, as with all `go-pluggable` plugins.
+
+The agent builds a dedicated `go-pluggable` manager for these events (it does
+*not* reuse the global agent-provider bus), so a misbehaving check plugin can
+never abort the install via `EventResponse.Error`. Discovery and every plugin
+response are logged (see "Logging").
+
+## Writing a provider
+
+A check plugin is an executable named `tui-check-<name>` placed in one of the
+directories above. It speaks the `go-pluggable` protocol: it is invoked with the
+event name as `argv[1]` and the JSON `Event` on stdin, and prints an
+`EventResponse` JSON to stdout.
+
+The easiest way to write one in Go is the `pluggable.PluginFactory` helper, as in
+the [diskwipe example](tui-check-diskwipe/main.go):
+
+```go
+factory := pluggable.NewPluginFactory(
+    pluggable.FactoryPlugin{EventType: prereqs.EventChecks, PluginHandler: onChecks},
+    pluggable.FactoryPlugin{EventType: prereqs.EventChecksApply, PluginHandler: onApply},
+)
+factory.Run(pluggable.EventType(os.Args[1]), os.Stdin, os.Stdout)
+```
+
+- `onChecks` inspects the system and returns `[]Check` (marshalled into
+  `EventResponse.Data`).
+- `onApply` reads the `ApplyPayload` from the event data, acts on the decisions
+  whose `ID` it owns, and returns `[]ApplyResult`.
+
+> **Important:** report problems through the returned data
+> (`Severity: "error"` on a check, or `Success: false` on a result), **never**
+> through `EventResponse.Error`. A non-empty `Error` is logged and that plugin's
+> checks are dropped.
+
+### Building and installing the examples
+
+```bash
+go build -o tui-check-diskwipe ./tui-check-examples/tui-check-diskwipe
+install -m 0755 tui-check-diskwipe /usr/local/system/tui-checks/
+
+go build -o tui-check-magicword ./tui-check-examples/tui-check-magicword
+install -m 0755 tui-check-magicword /usr/local/system/tui-checks/
+```
+
+On the next interactive install, `tui-check-diskwipe` lists any disk carrying
+`COS_*` partition labels in a multi-select; the selected disks are wiped
+(`wipefs`) before the install proceeds. `tui-check-magicword` blocks the install
+until the user types `jojo`.
+
+## Logging
+
+Plugin discovery and every plugin response are logged by the agent:
+
+- Which directories were scanned and which `tui-check-*` plugins were found (or
+  `No interactive-install check plugins found`).
+- The `checks`/`apply` events being published and how many checks/results came
+  back.
+- Per plugin: its state, error, data size, and — importantly — its captured
+  stdout/stderr. `go-pluggable` puts a plugin's own output in
+  `EventResponse.Logs`, which the agent re-logs line by line, so anything a
+  plugin prints (e.g. via `fmt.Fprintf(os.Stderr, …)`) reaches the agent log /
+  journald. Note this output is captured *during the handler*: a plugin must
+  write to `os.Stderr`/`os.Stdout` from inside the handler (resolving the
+  descriptor at call time), not cache it before `factory.Run`.
+
+## Testing
+
+`pkg/prereqs` is covered by unit tests for the contract helpers (`ParseChecks`,
+`Satisfied`, `Blocker`, `BuildDecisions`, `ClassifyFailures`, `DefaultAnswer`).
+
+The end-to-end round-trip is covered in
+`internal/agent/prerequisites_test.go`, which drives a dedicated bash test
+plugin (`internal/agent/testdata/tui-checks/tui-check-prereqtest`) that emits one
+check of every prompt type and records the apply payload, asserting the user's
+answers reach the plugin intact. The test builds its own `go-pluggable` manager
+loaded only with the fixture, mirroring the TUI and staying fully separate from
+the global agent-provider bus.

--- a/tui-check-examples/tui-check-diskwipe/main.go
+++ b/tui-check-examples/tui-check-diskwipe/main.go
@@ -1,0 +1,181 @@
+// tui-check-diskwipe is an example Kairos interactive-install check plugin
+// (a "tui-check"). It participates in the installer's pre-installation sanity
+// checks, a plugin set separate from the generic agent providers.
+//
+// It demonstrates the EventChecks / EventChecksApply round-trip defined in
+// pkg/prereqs:
+//
+//   - On EventChecks it scans the system's disks and, for any disk that still
+//     carries Kairos partition labels (COS_*) from a previous installation, it
+//     returns a multi-select check letting the user pick which disks to wipe.
+//   - On EventChecksApply it wipes the disks the user selected in the TUI
+//     (wipefs) and reports the result.
+//
+// Build it and drop the resulting binary, named with the "tui-check-" prefix,
+// into one of the check-plugin search paths (/system/tui-checks,
+// /usr/local/system/tui-checks, or the agent's working directory):
+//
+//	go build -o tui-check-diskwipe ./tui-check-examples/tui-check-diskwipe
+//	install -m0755 tui-check-diskwipe /usr/local/system/tui-checks/
+//
+// Anything this plugin writes to stdout/stderr is captured by go-pluggable into
+// the EventResponse.Logs field and re-logged by the agent, so the log lines
+// below show up in the agent's journal/log.
+//
+// NOTE: wiping a disk is destructive. The action only runs for disks the user
+// explicitly selects on the prerequisites screen.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/kairos-io/kairos-agent/v2/pkg/prereqs"
+	"github.com/kairos-io/kairos-sdk/ghw"
+	"github.com/mudler/go-pluggable"
+)
+
+// logf writes a log line to stderr. It MUST resolve os.Stderr at call time:
+// go-pluggable's factory.Run redirects os.Stdout/os.Stderr to a capture pipe
+// only while the handler runs and puts that output in EventResponse.Logs, which
+// the agent re-logs. Caching os.Stderr (e.g. log.SetOutput(os.Stderr) in main)
+// would write to the real terminal and the agent would never see it.
+func logf(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "tui-check-diskwipe: "+format+"\n", a...)
+}
+
+// checkID is the single check this provider emits. The disks the user selects
+// to wipe are carried in the multi-select answer (Decision.Selected).
+const checkID = "diskwipe"
+
+// kairosLabels are the partition filesystem labels a Kairos installation
+// leaves behind. Their presence on a disk indicates leftover data.
+var kairosLabels = map[string]bool{
+	"COS_GRUB":       true,
+	"COS_STATE":      true,
+	"COS_RECOVERY":   true,
+	"COS_OEM":        true,
+	"COS_PERSISTENT": true,
+	"COS_ACTIVE":     true,
+	"COS_PASSIVE":    true,
+	"COS_SYSTEM":     true,
+}
+
+func main() {
+	factory := pluggable.NewPluginFactory(
+		pluggable.FactoryPlugin{EventType: prereqs.EventChecks, PluginHandler: onChecks},
+		pluggable.FactoryPlugin{EventType: prereqs.EventChecksApply, PluginHandler: onApply},
+	)
+
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: tui-check-diskwipe <event>")
+		os.Exit(1)
+	}
+
+	// factory.Run dispatches to onChecks/onApply, capturing their stderr/stdout
+	// into EventResponse.Logs (which the agent re-logs). The event name arrives
+	// as argv[1] and the Event JSON on stdin.
+	if err := factory.Run(pluggable.EventType(os.Args[1]), os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// onChecks scans disks and, if any carry leftover Kairos partition labels,
+// returns a single multi-select check letting the user choose which disks to
+// wipe.
+func onChecks(_ *pluggable.Event) pluggable.EventResponse {
+	logf("scanning disks for leftover Kairos partitions")
+	var options []prereqs.Option
+
+	disks := ghw.GetDisks(ghw.NewPaths(""), nil)
+	logf("found %d disk(s) on the system", len(disks))
+	for _, disk := range disks {
+		var found []string
+		for _, p := range disk.Partitions {
+			if kairosLabels[p.FilesystemLabel] {
+				found = append(found, p.FilesystemLabel)
+			}
+		}
+		if len(found) == 0 {
+			continue
+		}
+		dev := "/dev/" + disk.Name
+		logf("disk %s has leftover Kairos partitions: %s", dev, strings.Join(found, ", "))
+		options = append(options, prereqs.Option{
+			ID:    dev,
+			Label: fmt.Sprintf("%s (%s)", dev, strings.Join(found, ", ")),
+		})
+	}
+
+	var checks []prereqs.Check
+	if len(options) > 0 {
+		checks = append(checks, prereqs.Check{
+			ID:         checkID,
+			Title:      "Leftover Kairos data detected",
+			Message:    fmt.Sprintf("%d disk(s) hold partitions from a previous installation", len(options)),
+			Severity:   prereqs.SeverityWarning,
+			Prompt:     prereqs.PromptMultiSelect,
+			PromptText: "Select disks to wipe (all data on them will be destroyed):",
+			Options:    options,
+		})
+	}
+	logf("returning %d check(s)", len(checks))
+
+	// Report results through the returned data, never through
+	// EventResponse.Error: the agent aborts the whole process on a provider
+	// error, which would kill the TUI.
+	return pluggable.EventResponse{Data: mustJSON(checks)}
+}
+
+// onApply wipes the disks the user selected.
+func onApply(e *pluggable.Event) pluggable.EventResponse {
+	var payload prereqs.ApplyPayload
+	if err := json.Unmarshal([]byte(e.Data), &payload); err != nil {
+		logf("invalid apply payload: %v", err)
+		return pluggable.EventResponse{Data: mustJSON([]prereqs.ApplyResult{
+			{ID: checkID, Success: false, Message: "invalid apply payload: " + err.Error()},
+		})}
+	}
+
+	var results []prereqs.ApplyResult
+	for _, d := range payload.Decisions {
+		if d.ID != checkID {
+			continue
+		}
+		logf("apply: %d disk(s) selected for wiping", len(d.Selected))
+		for _, dev := range d.Selected {
+			logf("wiping %s", dev)
+			res := prereqs.ApplyResult{ID: checkID, Success: true, Message: "wiped " + dev}
+			if err := wipe(dev); err != nil {
+				logf("wipe %s failed: %v", dev, err)
+				res.Success = false
+				res.Message = err.Error()
+			} else {
+				logf("wiped %s successfully", dev)
+			}
+			results = append(results, res)
+		}
+	}
+
+	return pluggable.EventResponse{Data: mustJSON(results)}
+}
+
+// wipe removes filesystem and partition-table signatures from a device.
+func wipe(dev string) error {
+	if out, err := exec.Command("wipefs", "-a", dev).CombinedOutput(); err != nil {
+		return fmt.Errorf("wipefs %s: %w (%s)", dev, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}

--- a/tui-check-examples/tui-check-magicword/main.go
+++ b/tui-check-examples/tui-check-magicword/main.go
@@ -1,0 +1,109 @@
+// tui-check-magicword is a deliberately dumb example interactive-install check
+// plugin (a "tui-check"). It exists to demonstrate the parts of the contract
+// the diskwipe example does not:
+//
+//   - A free-text prompt that collects input from the user.
+//   - A Required check whose apply step validates that input, so the install
+//     cannot continue until the user gets it right. A wrong answer surfaces a
+//     retry on the prerequisites screen.
+//
+// Behaviour: it asks the user to type a magic word. On apply it accepts only
+// "jojo"; anything else fails and the user is asked to retry.
+//
+//	go build -o tui-check-magicword ./tui-check-examples/tui-check-magicword
+//	install -m0755 tui-check-magicword /usr/local/system/tui-checks/
+//
+// Logs written to stderr are captured by go-pluggable into EventResponse.Logs
+// and re-logged by the agent.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kairos-io/kairos-agent/v2/pkg/prereqs"
+	"github.com/mudler/go-pluggable"
+)
+
+const (
+	checkID   = "magicword"
+	magicWord = "jojo"
+)
+
+func logf(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "tui-check-magicword: "+format+"\n", a...)
+}
+
+func main() {
+	factory := pluggable.NewPluginFactory(
+		pluggable.FactoryPlugin{EventType: prereqs.EventChecks, PluginHandler: onChecks},
+		pluggable.FactoryPlugin{EventType: prereqs.EventChecksApply, PluginHandler: onApply},
+	)
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: tui-check-magicword <event>")
+		os.Exit(1)
+	}
+	if err := factory.Run(pluggable.EventType(os.Args[1]), os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// onChecks returns a single required text check asking for the magic word.
+func onChecks(_ *pluggable.Event) pluggable.EventResponse {
+	logf("offering the magic-word check")
+	checks := []prereqs.Check{
+		{
+			ID:          checkID,
+			Title:       "Magic word required",
+			Message:     fmt.Sprintf("This node won't install until you say the magic word. (hint: it's %q)", magicWord),
+			Severity:    prereqs.SeverityInfo,
+			Required:    true,
+			Prompt:      prereqs.PromptText,
+			PromptText:  fmt.Sprintf("Type the magic word (%s):", magicWord),
+			Placeholder: magicWord,
+		},
+	}
+	return pluggable.EventResponse{Data: mustJSON(checks)}
+}
+
+// onApply validates the typed word. Only "jojo" succeeds; anything else fails,
+// which (because the check is Required) blocks the install and prompts a retry.
+func onApply(e *pluggable.Event) pluggable.EventResponse {
+	var payload prereqs.ApplyPayload
+	if err := json.Unmarshal([]byte(e.Data), &payload); err != nil {
+		logf("invalid apply payload: %v", err)
+		return pluggable.EventResponse{Data: mustJSON([]prereqs.ApplyResult{
+			{ID: checkID, Success: false, Message: "invalid apply payload: " + err.Error()},
+		})}
+	}
+
+	var results []prereqs.ApplyResult
+	for _, d := range payload.Decisions {
+		if d.ID != checkID {
+			continue
+		}
+		got := strings.TrimSpace(d.Text)
+		logf("user typed %q", got)
+		if got == magicWord {
+			results = append(results, prereqs.ApplyResult{ID: checkID, Success: true, Message: "the magic word is correct"})
+		} else {
+			results = append(results, prereqs.ApplyResult{
+				ID:      checkID,
+				Success: false,
+				Message: fmt.Sprintf("%q is not the magic word — try again", got),
+			})
+		}
+	}
+	return pluggable.EventResponse{Data: mustJSON(results)}
+}
+
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}


### PR DESCRIPTION
Add a pre-installation prerequisites/sanity-check screen to the
interactive installer, driven by a dedicated plugin set, plus the
contract, examples, docs and tests.

- pkg/prereqs: the check contract. Check carries Severity, Blocking,
  Required and one of four prompt types (confirm, text, single-select,
  multi-select); with Decision/Answer/payload types and helpers
  (ParseChecks, Satisfied, Blocker, BuildDecisions, ClassifyFailures,
  DefaultAnswer).

- TUI: a new "prerequisites" screen, the first interactive-install page.
  Auto-skips when no plugin returns checks. Each check renders in a
  severity-colored, content-fit box (info=blue, warning=orange,
  error=red) with the matching input widget. Blocking checks must be
  satisfied before continuing; a failed Required action blocks and
  offers retry, an optional failure can be skipped; a per-action results
  summary is shown.

- Dedicated plugin set: tui-check-<name> binaries discovered under
  /system/tui-checks and /usr/local/system/tui-checks via a dedicated
  go-pluggable manager, separate from the agent-provider bus so a check
  plugin can never abort the install. Discovery and the checks/apply
  round-trip are logged, including each plugin's captured output.

- Examples (tui-check-examples/): tui-check-diskwipe (optional
  multi-select wipe of disks with leftover Kairos data) and
  tui-check-magicword (required text prompt that demonstrates the retry
  path).

- Docs and tests: tui-check-examples/interactive-install-prerequisites.md,
  pkg/prereqs unit tests, and an end-to-end round-trip test driven by a
  bash tui-check fixture.