### PR TITLE
Stop reading deprecated /etc/elemental config directory

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -180,8 +180,7 @@ func GetYipConfigDirs() []string {
 func GetUserConfigDirs() []string {
 	return []string{
 		"/run/initramfs/live",
-		"/etc/kairos",    // Default system configuration file https://github.com/kairos-io/kairos/issues/2221
-		"/etc/elemental", // for backwards compatibility
+		"/etc/kairos", // Default system configuration file https://github.com/kairos-io/kairos/issues/2221
 		"/usr/local/cloud-config",
 		"/oem",
 	}

--- a/pkg/constants/constants_test.go
+++ b/pkg/constants/constants_test.go
@@ -7,6 +7,21 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("GetUserConfigDirs", func() {
+	It("no longer reads the deprecated /etc/elemental directory", func() {
+		Expect(constants.GetUserConfigDirs()).NotTo(ContainElement("/etc/elemental"))
+	})
+
+	It("still reads the supported config directories", func() {
+		Expect(constants.GetUserConfigDirs()).To(ContainElements(
+			"/run/initramfs/live",
+			"/etc/kairos",
+			"/usr/local/cloud-config",
+			"/oem",
+		))
+	})
+})
+
 var _ = Describe("Replace title", func() {
 	DescribeTable("Replacing the tile",
 		func(role, oldTitle, newTitle string) {


### PR DESCRIPTION
Since 3.0 users have been warned that reading configuration from /etc/elemental would be deprecated. Remove it from the set of user config directories so it is no longer scanned. Configuration should live in /etc/kairos (or the other supported locations).

Closes kairos-io/kairos#2233