### PR TITLE
fix(install): skip dm devices in target auto-detection

### DIFF
--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -1122,6 +1122,15 @@ func detectLargestDevice() string {
 	maxSize := float64(0)
 
 	for _, disk := range ghw.GetDisks(ghw.NewPaths(""), nil) {
+		// Skip device-mapper devices (multipath maps, LVM volumes). They are
+		// not valid install targets: the agent deactivates them through
+		// blkdeactivate right before partitioning, so installing onto one
+		// would fail with a missing device. Multipath claims any disk
+		// exposing a WWID (even single-path ones), shadowing the real disk
+		// with a dm-N node of the exact same size.
+		if strings.HasPrefix(disk.Name, "dm-") {
+			continue
+		}
 		size := float64(disk.SizeBytes) / float64(GiB)
 		if size > maxSize {
 			maxSize = size

--- a/pkg/config/spec_test.go
+++ b/pkg/config/spec_test.go
@@ -686,6 +686,38 @@ cloud-init-paths:
 				Expect(cfg.CloudInitPaths).To(ContainElement("/what"))
 
 			})
+			It("Skips device-mapper devices when auto-detecting the largest install device", func() {
+				// A multipath map (dm-0) over a single-path disk shows up in
+				// /sys/block alongside the disk itself and must never be picked
+				// as install target: the agent deactivates dm devices via
+				// blkdeactivate right before partitioning.
+				ghwTest.Clean()
+				ghwTest = ghwMock.GhwMock{}
+				ghwTest.AddDisk(sdkPartitions.Disk{Name: "sda", SizeBytes: 100})
+				ghwTest.AddDisk(sdkPartitions.Disk{
+					Name:      "dm-0",
+					SizeBytes: 200,
+					UUID:      "mpath-3600508b1001c7e72",
+				})
+				ghwTest.CreateDevices()
+
+				autoDir, err := os.MkdirTemp("", "kairos-auto-device-test-*")
+				Expect(err).ToNot(HaveOccurred())
+				defer os.RemoveAll(autoDir)
+				ccdata := []byte("#cloud-config\ninstall:\n  auto: true\n")
+				Expect(os.WriteFile(filepath.Join(autoDir, "cc.yaml"), ccdata, os.ModePerm)).To(Succeed())
+
+				cfg, err := config.ScanNoLogs(collector.Directories([]string{autoDir}...), collector.NoLogs)
+				Expect(err).ToNot(HaveOccurred())
+				cfg.Runner = runner
+				cfg.Fs = fs
+				cfg.Mounter = mounter
+				cfg.CloudInitRunner = ci
+				cfg.Logger = logger
+				installSpec, err := config.ReadInstallSpecFromConfig(cfg)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(installSpec.Target).To(Equal("/dev/sda"))
+			})
 			It("Resolves install.device via script:// and uses its stdout as the target", func() {
 				script, err := os.CreateTemp("", "pick-disk-*.sh")
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Images built with kairos-init >= v0.8.5 ship the multipath dracut module; multipathd claims any disk exposing a WWID (find_multipaths off), including single-path ones, creating a dm-N map of identical size that shadows the real disk. Auto-detection picked the map, then DeactivateDevices() ran blkdeactivate before partitioning and removed it, failing the install with "disk /dev/dm-0 does not exist".

Device-mapper devices are never valid install targets while the blkdeactivate pre-partitioning step exists, so skip them when detecting the largest disk.

Fixes https://github.com/kairos-io/kairos/issues/4125