### PR TITLE
Potential fix for code scanning alert no. 188: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 env:
   FORCE_COLOR: 1
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/kairos-io/kairos-agent/security/code-scanning/188](https://github.com/kairos-io/kairos-agent/security/code-scanning/188)

Add an explicit top-level `permissions` block in `.github/workflows/unit-tests.yml` so all jobs inherit least-privilege token access. For this workflow, the best minimal safe baseline is:

- `contents: read`

This preserves existing behavior for checkout/test execution while preventing unintended write access from defaults. Place the block near the top-level keys (for example after `on:` and before `env:`) so it applies to the `unit-tests` job without changing job logic, steps, or action versions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
