### PR TITLE
Potential fix for code scanning alert no. 187: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secscan.yaml
+++ b/.github/workflows/secscan.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
   - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kairos-io/kairos-agent/security/code-scanning/187](https://github.com/kairos-io/kairos-agent/security/code-scanning/187)

Add an explicit `permissions` block in `.github/workflows/secscan.yaml` at workflow root level (applies to all jobs unless overridden).  
For this workflow, the least-privilege set should be:

- `contents: read` (needed for checkout/read repo content)
- `security-events: write` (needed to upload SARIF results to code scanning)

This preserves current functionality while constraining token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
