### PR TITLE
Potential fix for code scanning alert no. 186: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kairos-io/kairos-agent/security/code-scanning/186](https://github.com/kairos-io/kairos-agent/security/code-scanning/186)

Add an explicit `permissions` block to `.github/workflows/release.yaml` so the workflow does not rely on implicit defaults.  
Best fix without changing intended functionality is to set workflow-level permissions appropriate for release publishing:

- `contents: write` (required to create/update GitHub Releases)
- `packages: write` (commonly needed if publishing packages/images)
- optionally `issues: write` / `pull-requests: write` only if your release process comments/updates those (not shown here, so omit)

In this snippet, add the block near the top-level (after `on:` and before `jobs:`), so it applies consistently to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
