### PR TITLE
Use kairos-sdk installer contract instead of private copy

### DIFF
--- a/internal/agent/installer_dispatch.go
+++ b/internal/agent/installer_dispatch.go
@@ -5,32 +5,9 @@ import (
 	"os/exec"
 )
 
-const installerEnvVar = "KAIROS_INSTALLER"
-
-// installerOverridePath and installerDefaultPath are the fixed image locations
-// for the installer. The override is checked first so a customizer can drop
-// their own binary next to (or in place of) the kairos-init-provided default.
-// They are vars (not consts) so tests can point them at temp files.
-var (
-	installerOverridePath = "/system/installer/installer"
-	installerDefaultPath  = "/system/installer/kairos-installer"
-)
-
-// resolveInstaller returns the path to an installer binary, or "" if none is
-// found. Order: KAIROS_INSTALLER env (must exist) -> override path -> default.
-func resolveInstaller() string {
-	if p := os.Getenv(installerEnvVar); p != "" {
-		if _, err := os.Stat(p); err == nil {
-			return p
-		}
-	}
-	for _, p := range []string{installerOverridePath, installerDefaultPath} {
-		if _, err := os.Stat(p); err == nil {
-			return p
-		}
-	}
-	return ""
-}
+// The installer locations and the resolution order (KAIROS_INSTALLER env ->
+// override path -> default path) are defined once in the kairos-sdk installer
+// package and consumed here via installer.Resolve.
 
 // installerCommand builds the *exec.Cmd that invokes the installer, forwarding
 // the install source when present. It does not wire stdio (see

--- a/internal/agent/installer_dispatch_test.go
+++ b/internal/agent/installer_dispatch_test.go
@@ -10,59 +10,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// writeExecutable creates an executable file at dir/name and returns its path.
-func writeExecutable(dir, name string) string {
-	p := filepath.Join(dir, name)
-	Expect(os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755)).To(Succeed())
-	return p
-}
-
-// writeFileAt creates an executable file at an absolute path.
-func writeFileAt(path string) {
-	Expect(os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755)).To(Succeed())
-}
-
-var _ = Describe("resolveInstaller", func() {
-	var tmp string
-
-	BeforeEach(func() {
-		tmp = GinkgoT().TempDir()
-		origOverride, origDefault := installerOverridePath, installerDefaultPath
-		installerOverridePath = filepath.Join(tmp, "override")
-		installerDefaultPath = filepath.Join(tmp, "default")
-		DeferCleanup(func() {
-			installerOverridePath, installerDefaultPath = origOverride, origDefault
-		})
-		GinkgoT().Setenv(installerEnvVar, "")
-	})
-
-	It("prefers KAIROS_INSTALLER when the file exists", func() {
-		bin := writeExecutable(tmp, "custom")
-		GinkgoT().Setenv(installerEnvVar, bin)
-		writeFileAt(installerDefaultPath)
-		Expect(resolveInstaller()).To(Equal(bin))
-	})
-
-	It("falls through when KAIROS_INSTALLER points to a missing file", func() {
-		GinkgoT().Setenv(installerEnvVar, filepath.Join(tmp, "nope"))
-		Expect(resolveInstaller()).To(BeEmpty())
-	})
-
-	It("uses the override path over the default when both exist", func() {
-		writeFileAt(installerOverridePath)
-		writeFileAt(installerDefaultPath)
-		Expect(resolveInstaller()).To(Equal(installerOverridePath))
-	})
-
-	It("uses the default path when only it exists", func() {
-		writeFileAt(installerDefaultPath)
-		Expect(resolveInstaller()).To(Equal(installerDefaultPath))
-	})
-
-	It("returns empty when nothing exists", func() {
-		Expect(resolveInstaller()).To(BeEmpty())
-	})
-})
+// Installer resolution (KAIROS_INSTALLER env -> override -> default) lives in the
+// kairos-sdk installer package and is tested there. These tests cover the
+// agent-specific exec wiring.
 
 var _ = Describe("installer dispatch", func() {
 	Describe("installerCommand", func() {

--- a/internal/agent/interactive_install.go
+++ b/internal/agent/interactive_install.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"fmt"
 
+	"github.com/kairos-io/kairos-sdk/constants"
+	"github.com/kairos-io/kairos-sdk/installer"
 	sdkLogger "github.com/kairos-io/kairos-sdk/types/logger"
 	"github.com/kairos-io/kairos-sdk/utils"
 )
@@ -12,10 +14,10 @@ import (
 // - spawnShell: if true, spawn a shell after the installer exits.
 // - source: installation source, forwarded to the installer.
 func InteractiveInstall(spawnShell bool, source string, logger sdkLogger.KairosLogger) error {
-	path := resolveInstaller()
+	path := installer.Resolve("/")
 	if path == "" {
 		return fmt.Errorf("no interactive installer found (looked for %s, %s; or set %s)",
-			installerOverridePath, installerDefaultPath, installerEnvVar)
+			constants.InstallerOverridePath, constants.InstallerDefaultPath, constants.InstallerEnvVar)
 	}
 
 	logger.Infof("Delegating interactive installation to %s", path)


### PR DESCRIPTION
The installer image locations and resolution order (KAIROS_INSTALLER env -> override -> default) are now defined once in the kairos-sdk installer package, shared with kairos-init. Drop the private consts and resolveInstaller from internal/agent and call installer.Resolve / constants.Installer* from the SDK instead.

The agent-specific exec wiring (installerCommand, runExternalInstaller) stays here. Resolution is now tested in the SDK, so this drops the resolveInstaller tests and keeps the exec tests.