### PR TITLE
Validate partitions fit disk

### DIFF
--- a/.github/workflows/e2e-insecure-registry.yml
+++ b/.github/workflows/e2e-insecure-registry.yml
@@ -1,4 +1,4 @@
-name: E2E insecure-registry
+name: E2E tests
 on:
   push:
     branches:
@@ -9,10 +9,10 @@ permissions:
 env:
   FORCE_COLOR: 1
 concurrency:
-  group: ci-e2e-insecure-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: ci-e2e-tests-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  e2e-insecure-registry:
+  e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build-test-iso: build-agent-e2e
 run-e2e-tests-with-iso:
 	ISO=$${ISO:-$$(ls -t $(CURDIR)/$(BUILD_DIR)/*.iso 2>/dev/null | head -1)} \
 		BASE_IMAGE=$(BASE_IMAGE) \
-		go test -tags e2e ./$(E2E_DIR)/ -count=1 -v --ginkgo.label-filter=insecure-registry --timeout 30m
+		go test -tags e2e ./$(E2E_DIR)/ -count=1 -v --ginkgo.label-filter="insecure-registry || partition-validation" --timeout 30m
 
 # 4. Build then run.
 run-e2e-tests: build-test-iso run-e2e-tests-with-iso

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -790,11 +790,12 @@ func NewUkiUpgradeSpec(cfg *sdkConfig.Config) (*spec.UpgradeUkiSpec, error) {
 		return spec, fmt.Errorf("could not read host partitions")
 	}
 
-	// Get free size of partition
+	// Get free size of partition in MiB so it can be compared with the image
+	// sizes, which are also in MiB.
 	var stat unix.Statfs_t
 	_ = unix.Statfs(spec.EfiPartition.MountPoint, &stat)
-	freeSize := stat.Bfree * uint64(stat.Bsize) / 1000 / 1000
-	cfg.Logger.Debugf("Partition on mountpoint %s has %dMb free", spec.EfiPartition.MountPoint, freeSize)
+	freeSize := stat.Bfree * uint64(stat.Bsize) / 1024 / 1024
+	cfg.Logger.Debugf("Partition on mountpoint %s has %dMiB free", spec.EfiPartition.MountPoint, freeSize)
 	// Check if the source is over the free size
 	if spec.Active.Size > uint(freeSize) {
 		return spec, fmt.Errorf("source size(%d) is bigger than the free space(%d) on the EFI partition(%s)", spec.Active.Size, freeSize, spec.EfiPartition.MountPoint)

--- a/pkg/config/spec.go
+++ b/pkg/config/spec.go
@@ -175,7 +175,7 @@ func NewInstallSpec(cfg *sdkConfig.Config) (*spec.InstallSpec, error) {
 	if err != nil {
 		cfg.Logger.Warnf("Failed to infer size for images: %s", err.Error())
 	} else {
-		cfg.Logger.Infof("Setting image size to %dMb", size)
+		cfg.Logger.Infof("Setting image size to %dMiB", size)
 		spec.Active.Size = uint(size)
 		spec.Passive.Size = uint(size)
 		spec.Recovery.Size = uint(size)
@@ -214,7 +214,7 @@ func NewInstallElementalPartitions(log sdkLogger.KairosLogger, spec *spec.Instal
 		MountPoint:      constants.OEMDir,
 		Flags:           []string{},
 	}
-	log.Infof("Setting OEM partition size to %dMb", oemSize)
+	log.Infof("Setting OEM partition size to %dMiB", oemSize)
 	// Double the space for recovery, as upgrades use the recovery partition to create the transition image for upgrades
 	// so we need twice the space to do a proper upgrade
 	// Check if the default/user provided values are enough to fit the images sizes
@@ -225,12 +225,12 @@ func NewInstallElementalPartitions(log sdkLogger.KairosLogger, spec *spec.Instal
 		if spec.Partitions.Recovery.Size < (spec.Recovery.Size*2)+200 { // Configured by user but not enough space
 			// If we had the logger here we could log a message saying that space is not enough and we are auto increasing it
 			recoverySize = (spec.Recovery.Size * 2) + 200
-			log.Warnf("Not enough space set for recovery partition(%dMb), increasing it to fit the recovery images(%dMb)", spec.Partitions.Recovery.Size, recoverySize)
+			log.Warnf("Not enough space set for recovery partition(%dMiB), increasing it to fit the recovery images(%dMiB)", spec.Partitions.Recovery.Size, recoverySize)
 		} else {
 			recoverySize = spec.Partitions.Recovery.Size
 		}
 	}
-	log.Infof("Setting recovery partition size to %dMb", recoverySize)
+	log.Infof("Setting recovery partition size to %dMiB", recoverySize)
 	pt.Recovery = &sdkPartitions.Partition{
 		FilesystemLabel: sdkConstants.RecoveryLabel,
 		Size:            recoverySize,
@@ -251,12 +251,12 @@ func NewInstallElementalPartitions(log sdkLogger.KairosLogger, spec *spec.Instal
 	} else {
 		if spec.Partitions.State.Size < (spec.Active.Size*2)+spec.Passive.Size+1000 { // Configured by user but not enough space
 			stateSize = (spec.Active.Size * 2) + spec.Passive.Size + 1000
-			log.Warnf("Not enough space set for state partition(%dMb), increasing it to fit the state images(%dMb)", spec.Partitions.State.Size, stateSize)
+			log.Warnf("Not enough space set for state partition(%dMiB), increasing it to fit the state images(%dMiB)", spec.Partitions.State.Size, stateSize)
 		} else {
 			stateSize = spec.Partitions.State.Size
 		}
 	}
-	log.Infof("Setting state partition size to %dMb", stateSize)
+	log.Infof("Setting state partition size to %dMiB", stateSize)
 	pt.State = &sdkPartitions.Partition{
 		FilesystemLabel: sdkConstants.StateLabel,
 		Size:            stateSize,
@@ -279,7 +279,7 @@ func NewInstallElementalPartitions(log sdkLogger.KairosLogger, spec *spec.Instal
 		MountPoint:      constants.PersistentDir,
 		Flags:           []string{},
 	}
-	log.Infof("Setting persistent partition size to %dMb", persistentSize)
+	log.Infof("Setting persistent partition size to %dMiB", persistentSize)
 	return pt
 }
 
@@ -443,14 +443,14 @@ func setUpgradeSourceSize(cfg *sdkConfig.Config, spec *spec.UpgradeSpec) error {
 	}
 
 	if uint(size) < originalSize {
-		cfg.Logger.Debugf("Calculated size (%dMB) is less than specified/default size (%dMB)", size, originalSize)
+		cfg.Logger.Debugf("Calculated size (%dMiB) is less than specified/default size (%dMiB)", size, originalSize)
 		targetSpec.Size = originalSize
 	} else {
-		cfg.Logger.Debugf("Calculated size (%dMB) is higher than specified/default size (%dMB)", size, originalSize)
+		cfg.Logger.Debugf("Calculated size (%dMiB) is higher than specified/default size (%dMiB)", size, originalSize)
 		targetSpec.Size = uint(size)
 	}
 
-	cfg.Logger.Infof("Setting image size to %dMB", targetSpec.Size)
+	cfg.Logger.Infof("Setting image size to %dMiB", targetSpec.Size)
 
 	return nil
 }
@@ -559,7 +559,7 @@ func NewResetSpec(cfg *sdkConfig.Config) (*spec.ResetSpec, error) {
 	if err != nil {
 		cfg.Logger.Warnf("Failed to infer size for images: %s", err.Error())
 	} else {
-		cfg.Logger.Infof("Setting image size to %dMb", size)
+		cfg.Logger.Infof("Setting image size to %dMiB", size)
 		spec.Active.Size = uint(size)
 		spec.Passive.Size = uint(size)
 	}
@@ -726,7 +726,7 @@ func NewUkiInstallSpec(cfg *sdkConfig.Config) (*spec.InstallUkiSpec, error) {
 	// Get the actual source size to calculate the image size and partitions size
 	size, err := GetSourceSize(cfg, spec.Active.Source)
 	if err != nil {
-		cfg.Logger.Warnf("Failed to infer size for images, leaving it as default size (%dMb): %s", spec.Partitions.EFI.Size, err.Error())
+		cfg.Logger.Warnf("Failed to infer size for images, leaving it as default size (%dMiB): %s", spec.Partitions.EFI.Size, err.Error())
 	} else {
 		// Only override if the calculated size is bigger than the default size, otherwise stay with 15Gb minimum
 		if uint(size*3) > spec.Partitions.EFI.Size {
@@ -734,7 +734,7 @@ func NewUkiInstallSpec(cfg *sdkConfig.Config) (*spec.InstallUkiSpec, error) {
 		}
 	}
 
-	cfg.Logger.Infof("Setting image size to %dMb", spec.Partitions.EFI.Size)
+	cfg.Logger.Infof("Setting image size to %dMiB", spec.Partitions.EFI.Size)
 
 	err = unmarshallFullSpec(cfg, "install", spec)
 
@@ -780,7 +780,7 @@ func NewUkiUpgradeSpec(cfg *sdkConfig.Config) (*spec.UpgradeUkiSpec, error) {
 		cfg.Logger.Warnf("Failed to infer size for images: %s", err.Error())
 		spec.Active.Size = sdkConstants.ImgSize
 	} else {
-		cfg.Logger.Infof("Setting image size to %dMb", size)
+		cfg.Logger.Infof("Setting image size to %dMiB", size)
 		spec.Active.Size = uint(size)
 	}
 
@@ -917,7 +917,7 @@ func GetSourceSize(config *sdkConfig.Config, source *sdkImages.ImageSource) (int
 		}
 		size = file.Size()
 	}
-	// Normalize size to MB before returning and add 100MB to round the size from bytes to MB+extra files like grub stuff
+	// Normalize size to MiB before returning and add 100MiB to round the size from bytes to MiB+extra files like grub stuff
 	if size != 0 {
 		size = (size / 1024 / 1024) + 100
 	}

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -300,7 +300,7 @@ func (e Elemental) UnmountImage(img *sdkImages.Image) error {
 
 // CreateFileSystemImage creates the image file for config.target
 func (e Elemental) CreateFileSystemImage(img *sdkImages.Image) error {
-	e.config.Logger.Infof("Creating file system image %s with size %dMb", img.File, img.Size)
+	e.config.Logger.Infof("Creating file system image %s with size %dMiB", img.File, img.Size)
 	err := fsutils.MkdirAll(e.config.Fs, filepath.Dir(img.File), cnst.DirPerm)
 	if err != nil {
 		return err

--- a/pkg/implementations/spec/spec.go
+++ b/pkg/implementations/spec/spec.go
@@ -52,9 +52,12 @@ type InstallSpec struct {
 // Sanitize checks the consistency of the struct, returns error
 // if unsolvable inconsistencies are found
 func (i *InstallSpec) Sanitize() error {
-	// Check if the target device has mounted partitions
+	// Check if the target device has mounted partitions, and remember its size
+	// so we can later make sure the requested partitions fit in it.
+	var targetDisk *partitions.Disk
 	for _, disk := range ghw.GetDisks(ghw.NewPaths(""), nil) {
 		if fmt.Sprintf("/dev/%s", disk.Name) == i.Target {
+			targetDisk = disk
 			for _, p := range disk.Partitions {
 				if p.MountPoint != "" {
 					return fmt.Errorf("target device %s has mounted partitions, please unmount them before installing", i.Target)
@@ -101,7 +104,47 @@ func (i *InstallSpec) Sanitize() error {
 	// we need them to be on fixed values, otherwise we wont know where to find things on boot, on reset, etc...
 	i.Partitions.SetDefaultLabels()
 
-	return i.Partitions.SetFirmwarePartitions(i.Firmware, i.PartTable)
+	if err := i.Partitions.SetFirmwarePartitions(i.Firmware, i.PartTable); err != nil {
+		return err
+	}
+
+	// Make sure the requested partitions actually fit in the target disk.
+	// Going over the disk size produces an unbootable system that only fails
+	// at first boot, so we fail early here instead.
+	return i.checkPartitionsFitTargetDisk(targetDisk)
+}
+
+// gptMetadataOverhead is the disk space the partitioner reserves and that the
+// partitions cannot use: 1MB of alignment before the first partition plus 1MB
+// at the end of the disk for the backup GPT header (see
+// pkg/partitioner/disk.go). We account for it so we reject a layout that would
+// not fit instead of letting the partitioning fail mid-install.
+const gptMetadataOverhead = 2 * 1024 * 1024
+
+// checkPartitionsFitTargetDisk returns an error if the sum of the requested
+// partition sizes does not fit in the target disk once the GPT metadata
+// overhead is reserved. A partition with size 0 means "take whatever space is
+// left on the disk", so it does not count towards the requested total. If the
+// target disk was not found (for example when the target is not set yet) the
+// check is skipped.
+func (i *InstallSpec) checkPartitionsFitTargetDisk(targetDisk *partitions.Disk) error {
+	if targetDisk == nil {
+		return nil
+	}
+
+	var requestedMB uint
+	for _, p := range i.Partitions.PartitionsByInstallOrder(i.ExtraPartitions) {
+		requestedMB += p.Size
+	}
+
+	// Partition sizes are expressed in MB while the disk size is in bytes.
+	if uint64(requestedMB)*1024*1024+gptMetadataOverhead > targetDisk.SizeBytes {
+		return fmt.Errorf(
+			"the requested partitions size (%dMB) does not fit in the target disk %q (%dMB), which also needs %dMB reserved for partition metadata",
+			requestedMB, i.Target, targetDisk.SizeBytes/(1024*1024), gptMetadataOverhead/(1024*1024))
+	}
+
+	return nil
 }
 
 func (i *InstallSpec) ShouldReboot() bool                            { return i.Reboot }

--- a/pkg/implementations/spec/spec.go
+++ b/pkg/implementations/spec/spec.go
@@ -115,7 +115,7 @@ func (i *InstallSpec) Sanitize() error {
 }
 
 // gptMetadataOverhead is the disk space the partitioner reserves and that the
-// partitions cannot use: 1MB of alignment before the first partition plus 1MB
+// partitions cannot use: 1MiB of alignment before the first partition plus 1MiB
 // at the end of the disk for the backup GPT header (see
 // pkg/partitioner/disk.go). We account for it so we reject a layout that would
 // not fit instead of letting the partitioning fail mid-install.
@@ -132,16 +132,16 @@ func (i *InstallSpec) checkPartitionsFitTargetDisk(targetDisk *partitions.Disk) 
 		return nil
 	}
 
-	var requestedMB uint
+	var requestedMiB uint
 	for _, p := range i.Partitions.PartitionsByInstallOrder(i.ExtraPartitions) {
-		requestedMB += p.Size
+		requestedMiB += p.Size
 	}
 
-	// Partition sizes are expressed in MB while the disk size is in bytes.
-	if uint64(requestedMB)*1024*1024+gptMetadataOverhead > targetDisk.SizeBytes {
+	// Partition sizes are expressed in MiB while the disk size is in bytes.
+	if uint64(requestedMiB)*1024*1024+gptMetadataOverhead > targetDisk.SizeBytes {
 		return fmt.Errorf(
-			"the requested partitions size (%dMB) does not fit in the target disk %q (%dMB), which also needs %dMB reserved for partition metadata",
-			requestedMB, i.Target, targetDisk.SizeBytes/(1024*1024), gptMetadataOverhead/(1024*1024))
+			"the requested partitions size (%dMiB) does not fit in the target disk %q (%dMiB), which also needs %dMiB reserved for partition metadata",
+			requestedMiB, i.Target, targetDisk.SizeBytes/(1024*1024), gptMetadataOverhead/(1024*1024))
 	}
 
 	return nil

--- a/pkg/implementations/spec/spec_test.go
+++ b/pkg/implementations/spec/spec_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kairos-io/kairos-agent/v2/pkg/constants"
 	"github.com/kairos-io/kairos-agent/v2/pkg/implementations/spec"
 	sdkConstants "github.com/kairos-io/kairos-sdk/constants"
+	ghwMock "github.com/kairos-io/kairos-sdk/ghw/mocks"
 	sdkImages "github.com/kairos-io/kairos-sdk/types/images"
 	sdkPartitions "github.com/kairos-io/kairos-sdk/types/partitions"
 	. "github.com/onsi/ginkgo/v2"
@@ -378,6 +379,50 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				}
 				err := sp.Sanitize()
 				Expect(err).ToNot(HaveOccurred())
+			})
+			Describe("partition sizes against the target disk", func() {
+				var ghwTest ghwMock.GhwMock
+				BeforeEach(func() {
+					// Present a 100MB target disk to ghw. The ghw mock writes this
+					// value into the kernel "size" file, which ghw reads back as a
+					// count of 512-byte sectors, so we express the wanted byte size
+					// in 512-byte sectors here to end up with a 100MB disk.
+					ghwTest = ghwMock.GhwMock{}
+					ghwTest.AddDisk(sdkPartitions.Disk{
+						Name:      "sda",
+						SizeBytes: 100 * 1024 * 1024 / 512,
+					})
+					ghwTest.CreateDevices()
+
+					sp.Active.Source = sdkImages.NewFileSrc("/tmp")
+					sp.Partitions.State = &sdkPartitions.Partition{MountPoint: "/tmp"}
+					sp.Firmware = sdkConstants.BiosPartName
+					sp.PartTable = sdkConstants.GPT
+					sp.Target = "/dev/sda"
+				})
+				AfterEach(func() {
+					ghwTest.Clean()
+				})
+				It("fails when the requested partitions exceed the disk size", func() {
+					sp.Partitions.Persistent = &sdkPartitions.Partition{Size: 200}
+					err := sp.Sanitize()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("does not fit in the target disk"))
+				})
+				It("fails when the partitions leave no room for the partition metadata", func() {
+					// 99MB persistent + 1MB BIOS = exactly the 100MB disk, leaving
+					// no room for the 1MB start alignment and the 1MB backup GPT
+					// header that the partitioner reserves.
+					sp.Partitions.Persistent = &sdkPartitions.Partition{Size: 99}
+					err := sp.Sanitize()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("does not fit in the target disk"))
+				})
+				It("passes when the requested partitions fit the disk size", func() {
+					sp.Partitions.Persistent = &sdkPartitions.Partition{Size: 10}
+					err := sp.Sanitize()
+					Expect(err).ToNot(HaveOccurred())
+				})
 			})
 		})
 		Describe("ResetSpec sanitize", func() {

--- a/pkg/implementations/spec/spec_test.go
+++ b/pkg/implementations/spec/spec_test.go
@@ -383,10 +383,10 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			Describe("partition sizes against the target disk", func() {
 				var ghwTest ghwMock.GhwMock
 				BeforeEach(func() {
-					// Present a 100MB target disk to ghw. The ghw mock writes this
+					// Present a 100MiB target disk to ghw. The ghw mock writes this
 					// value into the kernel "size" file, which ghw reads back as a
 					// count of 512-byte sectors, so we express the wanted byte size
-					// in 512-byte sectors here to end up with a 100MB disk.
+					// in 512-byte sectors here to end up with a 100MiB disk.
 					ghwTest = ghwMock.GhwMock{}
 					ghwTest.AddDisk(sdkPartitions.Disk{
 						Name:      "sda",
@@ -410,8 +410,8 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					Expect(err.Error()).To(ContainSubstring("does not fit in the target disk"))
 				})
 				It("fails when the partitions leave no room for the partition metadata", func() {
-					// 99MB persistent + 1MB BIOS = exactly the 100MB disk, leaving
-					// no room for the 1MB start alignment and the 1MB backup GPT
+					// 99MiB persistent + 1MiB BIOS = exactly the 100MiB disk, leaving
+					// no room for the 1MiB start alignment and the 1MiB backup GPT
 					// header that the partitioner reserves.
 					sp.Partitions.Persistent = &sdkPartitions.Partition{Size: 99}
 					err := sp.Sanitize()

--- a/tests/e2e/partition_validation_test.go
+++ b/tests/e2e/partition_validation_test.go
@@ -1,0 +1,100 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/spectrocloud/peg/matcher"
+)
+
+// oversizeError is the message Sanitize() returns when the requested manual
+// partitions do not fit in the target disk. Sanitize runs before the image is
+// pulled, so this surfaces without a successful pull having to happen first.
+const oversizeError = "bigger than the target disk"
+
+// The e2e VM is created with a 20000MB (~20GB) /dev/vda (see startVM's
+// WithDriveSize). The default layout (state ~10GB, recovery ~6GB, oem, bios)
+// already uses ~16.6GB, so tooBigConfig's 30000MB persistent partition cannot
+// possibly fit, while fittingConfig's 1024MB persistent leaves clear headroom.
+const (
+	tooBigConfig = `#cloud-config
+install:
+  device: "/dev/vda"
+  auto: true
+  reboot: false
+  poweroff: false
+  partitions:
+    persistent:
+      size: 30000
+users:
+- name: kairos
+  passwd: kairos
+  groups:
+    - admin
+`
+
+	fittingConfig = `#cloud-config
+install:
+  device: "/dev/vda"
+  auto: true
+  reboot: false
+  poweroff: false
+  partitions:
+    persistent:
+      size: 1024
+users:
+- name: kairos
+  passwd: kairos
+  groups:
+    - admin
+`
+)
+
+var _ = Describe("manual-install with custom partition sizes", Label("partition-validation"), func() {
+	var vm VM
+
+	BeforeEach(func() {
+		vm = startVM()
+		vm.EventuallyConnects(1200)
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			dumpSerial(vm)
+		}
+		Expect(vm.Destroy(nil)).ToNot(HaveOccurred())
+	})
+
+	// writeConfig drops the given cloud-config into the guest at /tmp/config.yaml.
+	writeConfig := func(content string) {
+		_, err := vm.Sudo(fmt.Sprintf("cat > /tmp/config.yaml <<'EOF'\n%s\nEOF", content))
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	It("fails before pulling when the partitions exceed the disk size", func() {
+		writeConfig(tooBigConfig)
+		out, err := vm.Sudo(fmt.Sprintf(
+			"kairos-agent manual-install --allow-insecure-registries --device /dev/vda --source %s /tmp/config.yaml",
+			sourceURI()))
+		Expect(err).To(HaveOccurred(), out)
+		Expect(out).To(ContainSubstring(oversizeError), out)
+		// Validation must short-circuit the install before the image is pulled,
+		// so the post-pull marker must never appear.
+		Expect(out).ToNot(ContainSubstring(postPullMarker), out)
+	})
+
+	It("gets past validation when the partitions fit the disk size", func() {
+		writeConfig(fittingConfig)
+		// With partitions that fit, the install proceeds past sanitization and
+		// pulls/unpacks the image. We only assert it cleared the new check and
+		// reached the pull stage; completing the whole install is out of scope.
+		out, _ := vm.Sudo(fmt.Sprintf(
+			"kairos-agent manual-install --allow-insecure-registries --device /dev/vda --source %s /tmp/config.yaml",
+			sourceURI()))
+		Expect(out).ToNot(ContainSubstring(oversizeError), out)
+		Expect(out).To(ContainSubstring(postPullMarker), out)
+	})
+})

--- a/tests/e2e/partition_validation_test.go
+++ b/tests/e2e/partition_validation_test.go
@@ -13,7 +13,7 @@ import (
 // oversizeError is the message Sanitize() returns when the requested manual
 // partitions do not fit in the target disk. Sanitize runs before the image is
 // pulled, so this surfaces without a successful pull having to happen first.
-const oversizeError = "bigger than the target disk"
+const oversizeError = "does not fit in the target disk"
 
 // The e2e VM is created with a 20000MB (~20GB) /dev/vda (see startVM's
 // WithDriveSize). The default layout (state ~10GB, recovery ~6GB, oem, bios)

--- a/tests/e2e/partition_validation_test.go
+++ b/tests/e2e/partition_validation_test.go
@@ -15,10 +15,10 @@ import (
 // pulled, so this surfaces without a successful pull having to happen first.
 const oversizeError = "does not fit in the target disk"
 
-// The e2e VM is created with a 20000MB (~20GB) /dev/vda (see startVM's
+// The e2e VM is created with a 20000MiB (~20GB) /dev/vda (see startVM's
 // WithDriveSize). The default layout (state ~10GB, recovery ~6GB, oem, bios)
-// already uses ~16.6GB, so tooBigConfig's 30000MB persistent partition cannot
-// possibly fit, while fittingConfig's 1024MB persistent leaves clear headroom.
+// already uses ~16.6GB, so tooBigConfig's 30000MiB persistent partition cannot
+// possibly fit, while fittingConfig's 1024MiB persistent leaves clear headroom.
 const (
 	tooBigConfig = `#cloud-config
 install:


### PR DESCRIPTION
Fail install early when manual partitions exceed the disk size

Closes kairos-io/kairos#2972

Problem

When a user defines manual partition sizes in the install cloud-config whose sum is larger than the target disk, the install used to proceed anyway and produce an unbootable system that only failed at first boot — e.g. immucore not finding COS_STATE, ending in a reboot loop (see the diagnosis on kairos-io/kairos#2950). There was no validation comparing the requested partition sizes against the target disk capacity, and the partitioner's flex-partition math (pkg/partitioner/disk.go) can even underflow when the fixed partitions already exceed the disk.

Change

InstallSpec.Sanitize() now sums the requested partition sizes (via PartitionsByInstallOrder, so firmware partitions are included) and fails with a clear error if they don't fit the target disk:
the requested partitions size (30001MB) does not fit in the target disk "/dev/vda" (20000MB), which also needs 2MB reserved for partition metadata

Details:
- Reserves the GPT metadata overhead the partitioner needs (1MB start alignment + 1MB backup GPT header), so a layout that would just barely not fit is rejected up front instead of failing mid-partitioning.
- Partitions with size: 0 ("take the remaining space") don't count toward the requested total.
- If the target disk can't be resolved yet (e.g. target unset), the check is skipped — no behavior change for existing paths.

Tests

- Unit (pkg/implementations/spec/spec_test.go, via the ghw mock): rejects an over-size layout, rejects a layout that fits the raw disk but leaves no room for GPT metadata, and accepts a fitting layout.
- e2e (tests/e2e/partition_validation_test.go): drives kairos-agent manual-install against the 20GB e2e VM disk — a 30000MB persistent config must fail at sanitization (before the image is pulled), and a fitting 1024MB persistent config must clear the check and reach the pull stage. Added the partition-validation label to the e2e label filter.


 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
