### PR TITLE
fix: handle "option" field kind in prerequisites multiselect control

### DIFF
--- a/internal/agent/TUIprerequisitesPage.go
+++ b/internal/agent/TUIprerequisitesPage.go
@@ -224,12 +224,18 @@ func (p *prerequisitesPage) control(cur *prereqField, dir int) {
 			a.Confirmed = !a.Confirmed
 		}
 	case "select":
+		// Single-select: ←/→ cycle through the options, keeping exactly one
+		// (or zero) selected.
 		next := cycleOption(c.Options, a.Selected, dir)
 		if next == "" {
 			a.Selected = nil
 		} else {
 			a.Selected = []string{next}
 		}
+	case "option":
+		// Multi-select: each option is its own focusable field. → selects,
+		// ← deselects, space toggles — independently per option, so any
+		// number of options can be selected at once.
 		id := c.Options[cur.optIdx].ID
 		if dir == 1 {
 			a.Selected = addUnique(a.Selected, id)


### PR DESCRIPTION
## Summary

Fixes the interactive-install **prerequisites** multiselect: pressing <kbd>space</kbd> / <kbd>←</kbd> / <kbd>→</kbd> on a `PromptMultiSelect` option did nothing, so the user could not select any option (let alone multiple). Cursor navigation worked, but selection never did — making any multiselect check (e.g. `tui-check-examples/tui-check-diskwipe`) unusable.

Refs kairos-io/kairos#4172.

## Root cause

`buildFields()` flattens every `PromptMultiSelect` option into a focusable field of kind **`"option"`**, but `control()` only handled `"confirm"` and `"select"`. The toggle keystroke reached `Update()`, routed to `control()`, and fell through with no effect.

The multiselect add/remove block was also mis-nested **inside the `"select"` case**, where it was unreachable for multiselect and incorrect for single-select (it re-added `Options[0]` on top of the cycled value).

## Fix

Split the conflated case:
- `"select"` keeps only the `cycleOption` single-value logic.
- a new `"option"` case toggles `a.Selected` by `c.Options[cur.optIdx].ID` — add on <kbd>→</kbd>, remove on <kbd>←</kbd>, toggle on <kbd>space</kbd>.

## Testing

Built this branch's `kairos-agent`, swapped it into a kairos-init v0.8.11 image (agent v2.27.4), rebuilt the installer ISO, booted in QEMU with 3 blank virtio disks, and drove `kairos-agent interactive-install` over the serial console.

**Before** (every keypress): no checkbox ever toggled.

**After:**

| Action | Result |
| --- | --- |
| space on `vda` | `[✓] vda` |
| space on `vdc` | `[✓] vda` **and** `[✓] vdc` |
| → on `vdb` | `[✓] vda` `[✓] vdb` `[✓] vdc` |
| space on `vda` | `[ ] vda` `[✓] vdb` `[✓] vdc` |

```
[✓] /dev/vda (4.0 GiB)
[ ] /dev/vdb (4.0 GiB)
[✓] /dev/vdc (4.0 GiB)     <- two non-adjacent disks selected
```

## Note on target branch

This feature (`internal/agent/TUIprerequisitesPage.go`, merged via #1242) lives only on the `release/v2.27.x` line and `preinstall_hooks_tui` — it is absent from `main`, `v2.28.x`, and `v2.29.x`. I targeted **`release/v2.27.4`** (its HEAD is the `v2.27.4` tag). The identical defect is present on `release/v2.27.2`, `release/v2.27.3`, and `preinstall_hooks_tui`; happy to retarget or cherry-pick wherever you prefer.
