### PR TITLE
fix: handle "option" field kind in prerequisites multiselect control

### DIFF
--- a/internal/agent/TUIprerequisitesPage.go
+++ b/internal/agent/TUIprerequisitesPage.go
@@ -224,12 +224,18 @@ func (p *prerequisitesPage) control(cur *prereqField, dir int) {
 			a.Confirmed = !a.Confirmed
 		}
 	case "select":
+		// Single-select: ←/→ cycle through the options, keeping exactly one
+		// (or zero) selected.
 		next := cycleOption(c.Options, a.Selected, dir)
 		if next == "" {
 			a.Selected = nil
 		} else {
 			a.Selected = []string{next}
 		}
+	case "option":
+		// Multi-select: each option is its own focusable field. → selects,
+		// ← deselects, space toggles — independently per option, so any
+		// number of options can be selected at once.
 		id := c.Options[cur.optIdx].ID
 		if dir == 1 {
 			a.Selected = addUnique(a.Selected, id)


### PR DESCRIPTION
The interactive-install prerequisites TUI flattens each PromptMultiSelect option into a focusable field of kind "option", but control() only handled "confirm" and "select". A space/left/right keystroke on a multiselect option reached Update(), routed to control(), and fell through with no effect, so no option could be toggled and nothing could be selected.

The multiselect add/remove block was also mis-nested inside the "select" case, where it was unreachable for multiselect and incorrect for single-select (it re-added Options[0] on top of the cycled value).

Split the cases: keep cycleOption under "select" (single value), and add an "option" case that toggles a.Selected by the focused option's ID (add on right, remove on left, toggle on space).

Verified in QEMU on agent v2.27.4 (kairos-init v0.8.11): multiple disks now select independently.