### PR TITLE
fix(phonehome): resolve agent binary path for systemd unit

### DIFF
--- a/internal/agent/phonehome_service.go
+++ b/internal/agent/phonehome_service.go
@@ -55,10 +55,11 @@ func enablePhoneHomeIfConfigured(c *sdkConfig.Config) {
 		c.Logger.Warnf("failed to resolve kairos-agent binary path: %v", err)
 		return
 	}
-	agentBin, err = filepath.EvalSymlinks(agentBin)
+	resolved, err := filepath.EvalSymlinks(agentBin)
 	if err != nil {
-		c.Logger.Warnf("failed to resolve kairos-agent binary path: %v", err)
-		return
+		c.Logger.Warnf("failed to eval symlinks for kairos-agent binary path %q: %v", agentBin, err)
+	} else {
+		agentBin = resolved
 	}
 
 	if err := os.WriteFile(phonehome.ServicePath, []byte(phoneHomeServiceUnit(agentBin)), 0600); err != nil {

--- a/internal/agent/phonehome_service.go
+++ b/internal/agent/phonehome_service.go
@@ -1,28 +1,32 @@
 package agent
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/kairos-io/kairos-agent/v2/internal/phonehome"
 	sdkConfig "github.com/kairos-io/kairos-sdk/types/config"
 )
 
-const phoneHomeServiceContent = `[Unit]
+func phoneHomeServiceUnit(agentBin string) string {
+	return fmt.Sprintf(`[Unit]
 Description=Kairos Agent Phone Home
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/sbin/kairos-agent phone-home
+ExecStart=%s phone-home
 Restart=on-failure
 RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
-`
+`, agentBin)
+}
 
 // enablePhoneHomeIfConfigured installs and starts the phone-home systemd service
 // when a `phonehome:` section with a url is present in the merged cloud-config.
@@ -46,7 +50,18 @@ func enablePhoneHomeIfConfigured(c *sdkConfig.Config) {
 
 	c.Logger.Infof("phone-home configuration detected, enabling phone-home service")
 
-	if err := os.WriteFile(phonehome.ServicePath, []byte(phoneHomeServiceContent), 0600); err != nil {
+	agentBin, err := os.Executable()
+	if err != nil {
+		c.Logger.Warnf("failed to resolve kairos-agent binary path: %v", err)
+		return
+	}
+	agentBin, err = filepath.EvalSymlinks(agentBin)
+	if err != nil {
+		c.Logger.Warnf("failed to resolve kairos-agent binary path: %v", err)
+		return
+	}
+
+	if err := os.WriteFile(phonehome.ServicePath, []byte(phoneHomeServiceUnit(agentBin)), 0600); err != nil {
 		c.Logger.Warnf("failed to write phone-home service: %v", err)
 		return
 	}

--- a/internal/agent/phonehome_service_test.go
+++ b/internal/agent/phonehome_service_test.go
@@ -1,0 +1,17 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPhoneHomeServiceUnit(t *testing.T) {
+	unit := phoneHomeServiceUnit("/usr/bin/kairos-agent")
+
+	if !strings.Contains(unit, "ExecStart=/usr/bin/kairos-agent phone-home") {
+		t.Fatalf("ExecStart should use the provided binary path, got:\n%s", unit)
+	}
+	if strings.Contains(unit, "/usr/sbin/kairos-agent") {
+		t.Fatalf("unit should not hardcode /usr/sbin/kairos-agent, got:\n%s", unit)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace the hardcoded `ExecStart=/usr/sbin/kairos-agent phone-home` in the phone-home systemd unit with the path of the running `kairos-agent start` process (`os.Executable()` + `filepath.EvalSymlinks()`).
- Fixes systemd **203/EXEC** failures on Ubuntu-based Kairos images where the binary is installed under `/usr/bin/kairos-agent`.

Fixes kairos-io/kairos#4178

## Test plan
- [ ] Unit test: `TestPhoneHomeServiceUnit` verifies the generated unit uses the provided binary path.
- [ ] Boot an Ubuntu-based Kairos node with `phonehome:` cloud-config, run `kairos-agent start`, and confirm `systemctl status kairos-agent-phonehome` shows `Active: active (running)` with the correct `ExecStart` path.
- [ ] Confirm the node registers with AuroraBoot / phone-home server (`POST /api/v1/nodes/register`).


Made with [Cursor](https://cursor.com)