### PR TITLE
feat: announce the shutdown/reboot grace period to the user

### DIFF
--- a/internal/agent/hooks/lifecycle.go
+++ b/internal/agent/hooks/lifecycle.go
@@ -1,6 +1,7 @@
 package hook
 
 import (
+	"fmt"
 	"time"
 
 	sdkConfig "github.com/kairos-io/kairos-sdk/types/config"
@@ -8,19 +9,31 @@ import (
 	"github.com/kairos-io/kairos-sdk/utils"
 )
 
+// lifecycleGracePeriod is how long we wait before rebooting or powering off, so
+// that an interactive user has a chance to cancel the request.
+const lifecycleGracePeriod = 5 * time.Second
+
 type Lifecycle struct{}
 
 func (s Lifecycle) Run(c sdkConfig.Config, spec sdkSpec.Spec) error {
 	c.Logger.Logger.Debug().Msg("Running Lifecycle hook")
 	if spec.ShouldReboot() {
-		time.Sleep(5 * time.Second)
+		c.Logger.Logger.Info().Msg(gracePeriodMessage("Rebooting node"))
+		time.Sleep(lifecycleGracePeriod)
 		utils.Reboot()
 	}
 
 	if spec.ShouldShutdown() {
-		time.Sleep(5 * time.Second)
+		c.Logger.Logger.Info().Msg(gracePeriodMessage("Powering off node"))
+		time.Sleep(lifecycleGracePeriod)
 		utils.PowerOFF()
 	}
 	c.Logger.Logger.Debug().Msg("Finish Lifecycle hook")
 	return nil
+}
+
+// gracePeriodMessage builds the message shown to the user before the node
+// reboots or powers off, telling them how long they have to cancel.
+func gracePeriodMessage(action string) string {
+	return fmt.Sprintf("%s in %s, press Ctrl+C to cancel", action, lifecycleGracePeriod)
 }

--- a/internal/agent/hooks/lifecycle_test.go
+++ b/internal/agent/hooks/lifecycle_test.go
@@ -1,0 +1,29 @@
+package hook
+
+import "testing"
+
+func TestGracePeriodMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   string
+		expected string
+	}{
+		{
+			name:     "power off message announces the grace period and how to cancel",
+			action:   "Powering off node",
+			expected: "Powering off node in 5s, press Ctrl+C to cancel",
+		},
+		{
+			name:     "reboot message announces the grace period and how to cancel",
+			action:   "Rebooting node",
+			expected: "Rebooting node in 5s, press Ctrl+C to cancel",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gracePeriodMessage(tt.action); got != tt.expected {
+				t.Fatalf("gracePeriodMessage(%q) = %q, want %q", tt.action, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The lifecycle hook waits 5 seconds before rebooting or powering off so an interactive user can cancel, but it did so silently. Log a message before the wait telling the user what is about to happen and that they have the grace period to cancel it.

The 5 second wait is extracted into a named lifecycleGracePeriod constant and the message into a pure gracePeriodMessage helper so the wording can be unit tested without triggering an actual reboot.

Refs kairos-io/kairos#3126