### PR TITLE
fix(security): clear unfixed OSV findings on main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 )
 
 require (
-	github.com/containerd/containerd v1.7.33
+	github.com/containerd/containerd/v2 v2.3.2
 	github.com/distribution/reference v0.6.0
 	github.com/foxboron/go-uefi v0.0.0-20251010190908-d29549a44f29
 	github.com/go-viper/mapstructure/v2 v2.5.0
@@ -82,7 +82,6 @@ require (
 	github.com/codingsince1985/checksum v1.2.4 // indirect
 	github.com/containerd/cgroups/v3 v3.1.3 // indirect
 	github.com/containerd/console v1.0.5 // indirect
-	github.com/containerd/containerd/v2 v2.3.2 // indirect
 	github.com/containerd/continuity v0.5.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
-github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
-github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
 github.com/containerd/containerd/api v1.11.1 h1:h8nfoDW9+fNsC/9TwiAHj8B1GzXKtR4eFtkhi/X5RLU=
 github.com/containerd/containerd/api v1.11.1/go.mod h1:CaQFRu+N1MtbgL6JDOJLUB1hCKESU1lD6MuTJhgtdlw=
 github.com/containerd/containerd/v2 v2.3.2 h1:eLven1YxRMkeiKu7IcMrPKE+gn8sGR1DqHbbshMEvWM=

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,7 @@
 [[IgnoredVulns]]
 id = "GHSA-q7pp-wcgr-pffx"
 reason = "No impact since we don't work with TIFF image files"
+
+[[IgnoredVulns]]
+id = "GHSA-9r4w-jg96-92mv"
+reason = "No fix available in github.com/google/go-attestation yet; pulled in transitively by tpm-helpers for TPM attestation and not used to parse untrusted EFI signature lists"

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -26,7 +26,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd/archive"
+	"github.com/containerd/containerd/v2/pkg/archive"
 	"github.com/diskfs/go-diskfs/partition/gpt"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"


### PR DESCRIPTION
## Summary

- Migrate `pkg/elemental` from `github.com/containerd/containerd` v1.7.33 to `github.com/containerd/containerd/v2` v2.3.2 for tar archive extraction. v2.3.2 includes fixes for the three reported containerd CRI checkpoint CVEs (GO-2026-5064, GO-2026-5338, GO-2026-5622).
- Ignore `GHSA-9r4w-jg96-92mv` (GO-2026-5298) in `osv-scanner.toml` — no fixed release of `github.com/google/go-attestation` is available yet; it is pulled in transitively by tpm-helpers.

## Test plan

- [x] `osv-scanner scan --config=osv-scanner.toml -L go.mod` reports no issues
- [x] `go test ./pkg/elemental/...`
- [ ] CI OSV-Scanner PR Scan job


Made with [Cursor](https://cursor.com)